### PR TITLE
Rp calcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ test_outputs/*
 *.sql
 
 data/*
+
+src.egg-info/*

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test_outputs/*
 *.db-journal
 *.sql
 
+*.cfg
 data/*
 
 src.egg-info/*

--- a/exploration/check_return_period_funcs.py
+++ b/exploration/check_return_period_funcs.py
@@ -1,0 +1,179 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: ds-raster-stats
+#     language: python
+#     name: ds-raster-stats
+# ---
+
+# %%
+# %matplotlib inline
+# %load_ext autoreload
+# %autoreload 2
+
+# %%
+from src.utils import cloud_utils
+from src.utils import return_periods as rp
+import pandas as pd
+import numpy as np
+from io import BytesIO
+import pyarrow
+from azure.storage.blob import BlobServiceClient
+import re
+from scipy.stats import beta
+import matplotlib.pyplot as plt
+from matplotlib.ticker import FuncFormatter
+
+def to_snake_case(name):
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+    
+sample_admin = "Awdal" # just used for plotting checking
+# %% [markdown]
+# Load data
+
+# %%
+pc = cloud_utils.get_container_client(mode="dev", container_name="projects")
+blob_name = "ds-floodscan-ingest/df_aer_sfed_som_adm1_zstats.parquet"
+blob_client = pc.get_blob_client(blob_name)
+blob_data = blob_client.download_blob().readall()
+df = pd.read_parquet(BytesIO(blob_data))
+df.columns = [to_snake_case(col) for col in df.columns]
+
+# %% [markdown]
+# ## Pre Process Data
+#
+# So just take yearly max values
+
+# %%
+df["year"] = pd.to_datetime(df["date"]).dt.year
+df_max = df.groupby(["adm1_en", "adm1_pcode", "year"]).max().reset_index()
+
+# %% [markdown]
+# ## Calculate LP3 Params
+#
+# Show the implementation by first just doing each method one by one on a single sample admin
+
+# %%
+rp.lp3_params(df_max[df_max["adm1_en"]==sample_admin].value,est_method = "usgs")
+
+
+# %%
+rp.lp3_params(df_max[df_max["adm1_en"]==sample_admin].value,est_method = "lmoments")
+
+# %%
+rp.lp3_params(df_max[df_max["adm1_en"]==sample_admin].value,est_method = "scipy")
+
+# %% [markdown]
+# We can also run them all at once with this wrapper
+
+# %%
+rp.lp3_params_all2(df_max[df_max["adm1_en"]==sample_admin].value)
+
+# %% [markdown]
+# Use wrapper function with `groupby` to run for each admin
+
+# %%
+df_params = df_max.groupby("adm1_en")["value"].apply(rp.lp3_params_all).reset_index().rename(columns={"level_1": "method"})
+
+# %% [markdown]
+# ## Calculate RPs
+#
+# Now we can loop through each admin and calculate RPs associated with each value
+
+# %%
+unique_adm1s = df_params_long["adm1_en"].unique()
+df_list = []
+
+for adm in unique_adm1s:
+    df_params_adm_filt = df_params[df_params["adm1_en"] == adm]
+    df_adm_filt = df[df["adm1_en"] == adm]
+    
+    est_methods = ["lmoments", "scipy", "usgs"]
+
+    for method in est_methods:
+        df_adm_filt[f"rp_{method}"] = rp.lp3_rp(
+            x=df_adm_filt["value"],
+            params=df_params_adm_filt.loc[df_params_adm_filt["method"] == method, "value"].iloc[0],
+            est_method=method
+        )
+    
+    df_list.append(df_adm_filt)
+
+# Concatenate all the dataframes in the list
+df_combined = pd.concat(df_list, ignore_index=True)
+
+
+# %% [markdown]
+# Plot all RPs from each method - can see that they are generally similar, but plot is not very useful.
+
+# %%
+df_combined_sample = df_combined[df_combined["adm1_en"]==sample_admin]
+
+# Plot RP values against 'value' for different estimation methods
+plt.figure(figsize=(10, 6))
+
+# Plot for lmoments
+plt.scatter(df_combined_sample["value"], df_combined_sample["rp_lmoments"], color='blue', label='RP Lmoments', alpha=0.5)
+
+# Plot for scipy
+plt.scatter(df_combined_sample["value"], df_combined_sample["rp_scipy"], color='green', label='RP Scipy', alpha=0.5)
+
+# Plot for usgs
+plt.scatter(df_combined_sample["value"], df_combined_sample["rp_usgs"], color='red', label='RP USGS', alpha=0.5)
+
+plt.xlabel('Value')
+plt.ylabel('Return Period (RP)')
+plt.title('Return Periods (RP) vs Value')
+plt.legend()
+plt.xscale('log')
+plt.yscale('log')
+plt.grid(True, which="both", ls="--")
+plt.show()
+
+
+# %% [markdown]
+# ## Plot RVs for Specified RPs
+#
+# for a better comparison we can calculate RVs for specified RPs `1-1000` for the sample admin
+
+# %%
+
+return_periods = np.arange(1, 10000)
+
+params_sample_lmom = df_params.loc[(df_params["method"] == "lmoments") & (df_params["adm1_en"] == sample_admin), "value"].iloc[0]
+params_sample_usgs = df_params.loc[(df_params["method"] == "usgs") & (df_params["adm1_en"] == sample_admin), "value"].iloc[0]
+params_sample_scipy = df_params.loc[(df_params["method"] == "scipy") & (df_params["adm1_en"] == sample_admin), "value"].iloc[0]
+# Calculate return values for each return period using lmoments method
+
+# import inspect
+# inspect.getsourcelines(rp.lp3_rv)
+return_values_lmom = rp.lp3_rv(rp=return_periods, params=params_sample_lmom, est_method="lmoments")
+return_values_usgs = rp.lp3_rv(rp=return_periods, params=params_sample_usgs, est_method="usgs")
+return_values_scipy = rp.lp3_rv(rp=return_periods, params=params_sample_scipy, est_method="scipy")
+
+# Plot the return periods against the return values
+plt.figure(figsize=(10, 6))
+plt.plot(return_periods, return_values_lmom * 100, label='LMoments', color='blue')
+plt.plot(return_periods, return_values_usgs * 100, label='USGS', color='red')
+plt.plot(return_periods, return_values_scipy * 100, label='SCIPY', color='green')
+plt.xlabel('Return Period')
+plt.ylabel('Return Value (%)')
+plt.title('Return Values vs Return Periods')
+plt.xscale('log')
+plt.yscale('log')
+plt.legend()
+plt.grid(True, which="both", ls="--")
+# Format y-axis to percentage
+plt.gca().yaxis.set_major_formatter(FuncFormatter(lambda y, _: '{:.0f}%'.format(y)))
+plt.show()
+
+

--- a/exploration/check_return_period_funcs.py
+++ b/exploration/check_return_period_funcs.py
@@ -76,7 +76,7 @@ rp.lp3_params(df_max[df_max["adm1_en"]==sample_admin].value,est_method = "scipy"
 # We can also run them all at once with this wrapper
 
 # %%
-rp.lp3_params_all2(df_max[df_max["adm1_en"]==sample_admin].value)
+rp.lp3_params_all(df_max[df_max["adm1_en"]==sample_admin].value)
 
 # %% [markdown]
 # Use wrapper function with `groupby` to run for each admin
@@ -90,7 +90,7 @@ df_params = df_max.groupby("adm1_en")["value"].apply(rp.lp3_params_all).reset_in
 # Now we can loop through each admin and calculate RPs associated with each value
 
 # %%
-unique_adm1s = df_params_long["adm1_en"].unique()
+unique_adm1s = df_params["adm1_en"].unique()
 df_list = []
 
 for adm in unique_adm1s:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 79
+
+[tool.isort]
+profile = "black"
+line_length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+name = src
+
+[options]
+packages = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[metadata]
-name = src
-
-[options]
-packages = src

--- a/src/utils/return_periods.py
+++ b/src/utils/return_periods.py
@@ -28,16 +28,16 @@ def lp3_params(x, est_method="lmoments"):
     return params
 
 
-def lp3_params_all(group):
+def lp3_params_all(value):
     methods = ["usgs", "lmoments", "scipy"]
-    params = {method: lp3_params(group["value"], method) for method in methods}
+    params = {method: lp3_params(value, method) for method in methods}
     return pd.Series(params)
 
 
 def lp3_rp(x, params, est_method="lmoments"):
     x = np.asarray(x)
     x_sorted = np.sort(x)
-    x_log = np.log(x_sorted)
+    x_log = np.log10(x_sorted)
 
     if est_method == "scipy":
         # Calculate the CDF for the log-transformed data
@@ -64,7 +64,7 @@ def lp3_rp(x, params, est_method="lmoments"):
 
     else:
         raise ValueError(
-            "Invalid package specified. Choose 'distr' or 'scipy'."
+            "Invalid package specified. Choose 'distr' , 'usgs',or 'scipy'."
         )
 
     # Calculate the return periods

--- a/src/utils/return_periods.py
+++ b/src/utils/return_periods.py
@@ -4,162 +4,107 @@ from scipy.stats import skew, norm, pearson3
 from lmoments3 import distr, lmom_ratios
 
 
-def params_lp3_usgs(x, imputation_method="lowest"):
-    """
-    Calculate the parameters for the Log-Pearson Type III distribution using USGS method.
+def lp3_params(x, est_method="lmoments"):
+    x = np.asarray(x)
+    x[x == 0] = np.min(x[x != 0])
+    x_sorted = np.sort(x)
+    x_log = np.log10(x_sorted)
 
-    Parameters:
-    x (array-like): Array of observed data.
-    imputation_method (str): Method for handling non-positive values in the data. Default is "lowest".
-
-    Returns:
-    dict: Dictionary containing the mean (mu), standard deviation (sd), and skewness (g) of the log-transformed data.
-
-    Example:
-    >>> import numpy as np
-    >>> data = np.array([10, 20, 30, 40, 50])
-    >>> params_lp3_usgs(data)
-    {'mu': np.float64(1.415836249209525),'sd': np.float64(0.2759982424449524),'g': np.float64(-0.5854140744039718)}
-    """
-    if imputation_method == "lowest":
-        x = np.where(x <= 0, np.min(x[np.nonzero(x)]), x)
-    x_log = np.log10(x)
-    return {"mu": np.mean(x_log), "sd": np.std(x_log, ddof=1), "g": skew(x_log)}
-
-
-def return_value_lp3_usgs(x, return_period):
-    """
-    Calculate the Log-Pearson Type III return value for given return periods using USGS method.
-
-    Parameters:
-    x (array-like): Array of observed data.
-    return_period (float): Return period for which the quantile is calculated.
-
-    Returns:
-    float: return value for the given return period.
-
-    Example:
-    >>> import numpy as np
-    >>> data = np.array([10, 20, 30, 40, 50])
-    >>> return_value_lp3_usgs(data, 100)
-    np.float64(86.91377279516328)
-    """
-    params = params_lp3_usgs(x)
-    g = params["g"]
-    mu = params["mu"]
-    stdev = params["sd"]
-
-    rp_exceedance = 1 / return_period
-    q_rp_norm = norm.ppf(1 - rp_exceedance)  # Normal quantiles
-    k_rp = (2 / g) * (
-        ((q_rp_norm - (g / 6)) * (g / 6) + 1) ** 3 - 1
-    )  # Skewness adjustment
-    y_fit_rp = mu + k_rp * stdev  # Fitted values for return periods
-    quantiles_rp = 10**y_fit_rp
-    return quantiles_rp
-
-
-def return_period_lp3_lmom(x, params):
-    """
-    Calculate the return period for given data and Log-Pearson Type III parameters.
-
-    Args:
-        x (array-like): Array of observed data.
-        params (tuple): Parameters of the Log-Pearson Type III distribution.
-
-    Returns:
-        float: Return period.
-
-    Example:
-        >>> import numpy as np
-        >>> from lmoments3 import distr, lmom_ratios
-        >>> data = np.array([10, 20, 30, 40, 50])
-        >>> params = params_lp3_lmom(data)
-        >>> return_period_lp3_lmom(30, params)
-        np.float64(9.264029097369093)
-    """
-    # Calculate the cumulative distribution function (CDF) value
-    p_lte = distr.pe3.cdf(x, **params)
-    p_gte = 1 - p_lte
-    rp = 1 / p_gte
-    return rp
-
-
-def params_lp3_lmom(x):
-    """
-    Calculate the parameters for the Log-Pearson Type III distribution using L-moments.
-
-    Args:
-        x (array-like): Array of observed data.
-
-    Returns:
-        dict: Dictionary containing the parameters of the Log-Pearson Type III distribution.
-    Examples:
-        >>> import numpy as np
-        >>> from return_periods import lp3_params_lmom
-        >>> data = np.array([1.2, 2.3, 3.4, 4.5, 5.6])
-        >>> params = lp3_params_lmom(data)
-        >>> print(params)
-        OrderedDict({'skew': 3.9736810031063223, 'loc': np.float64(1.125), 'scale': np.float64(2.459845871608456)})
-    """
-
-    # Compute L-moments
-    lmom = lmom_ratios(x, nmom=4)
-    # Fit the Log-Pearson Type III distribution using L-moments
-    params = distr.pe3.lmom_fit(lmom)
+    if est_method == "lmoments":
+        lmoments = lmom_ratios(x_log, nmom=4)
+        params = distr.pe3.lmom_fit(x_log, lmoments)  # , lmom_ratios=lmom/)
+    elif est_method == "scipy":
+        params = pearson3.fit(x_log, method="MM")
+    elif est_method == "usgs":
+        params = {
+            "mu": np.mean(x_log),
+            "sd": np.std(x_log, ddof=1),
+            "g": skew(x_log),
+        }
+    else:
+        raise ValueError(
+            "Invalid est_method specified. Choose 'usgs','lmoments' or 'scipy'."
+        )
     return params
 
 
-def return_value_lp3_lmom(x, return_period, params):
-    """
-    Calculate the Log-Pearson Type III return value for given return periods using L-moments.
-
-    Args:
-        x (array-like): Array of observed data.
-        return_period (float): Return period for which the quantile is calculated.
-        params (tuple): Parameters of the Log-Pearson Type III distribution.
-
-    Returns:
-        float: Return value for the given return period.
-
-    Example:
-        >>> import numpy as np
-        >>> data = np.array([10, 20, 30, 40, 50])
-        >>> params = params_lp3_lmom(data)
-        >>> return_value_lp3_lmom(data, 100, params)
-        np.float64(86.91377279516328)
-    """
-    rp_exceedance = 1 / return_period
-    quantile = distr.pe3.isf(rp_exceedance, **params)
-    return quantile
+def lp3_params_all(group):
+    methods = ["usgs", "lmoments", "scipy"]
+    params = {method: lp3_params(group["value"], method) for method in methods}
+    return pd.Series(params)
 
 
-def return_value(x, return_period, method="usgs"):
-    """
-    Calculate the return value for given return periods using specified method.
+def lp3_rp(x, params, est_method="lmoments"):
+    # Log-transform the data
+    x = np.asarray(x)
+    # x[x <= 0] = np.min(x[x > 0])
+    x_sorted = np.sort(x)
+    x_log = np.log(x_sorted)
 
-    Parameters:
-    x (array-like): Array of observed data.
-    return_period (float): Return period for which the quantile is calculated.
-    method (str): Method to use for calculation ("usgs" or "lmom"). Default is "usgs".
+    if est_method == "scipy":
+        # Calculate the CDF for the log-transformed data
+        p_lte = pearson3.cdf(x_log, *params)
 
-    Returns:
-    float: Return value for the given return period.
+    elif est_method == "lmoments":
+        p_lte = distr.pe3.cdf(x_log, **params)
 
-    Example:
-    >>> import numpy as np
-    >>> data = np.array([10, 20, 30, 40, 50])
-    >>> return_value(data, 100, method="usgs")
-    np.float64(86.91377279516328)
-    >>> return_value(data, 100, method="lmom")
-    np.float64(86.91377279516328)
-    """
-    method = method.lower()
-    if method not in ["usgs", "lmom"]:
-        raise ValueError("Invalid method. Choose 'usgs' or 'lmom'.")
+    elif est_method == "usgs":
+        g = params["g"]
+        mu = params["mu"]
+        stdev = params["sd"]
+        # Step 1: From quantiles_rp to y_fit_rp
+        y_fit_rp = x_log
 
-    if method == "usgs":
-        return return_value_lp3_usgs(x, return_period)
-    elif method == "lmom":
-        params = params_lp3_lmom(x)
-        return return_value_lp3_lmom(x, return_period, params)
+        # Step 2: From y_fit_rp to k_rp
+        k_rp = (y_fit_rp - mu) / stdev
+
+        # Step 3: From k_rp to q_rp_norm
+        q_rp_norm = (g / 6) + ((k_rp * g / 2 + 1) ** (1 / 3) - 1) * 6 / g
+
+        # Step 4: From q_rp_norm to rp_exceedance
+        p_lte = norm.cdf(q_rp_norm, loc=0, scale=1)
+
+    else:
+        raise ValueError(
+            "Invalid package specified. Choose 'distr' or 'scipy'."
+        )
+
+    # Calculate the return periods
+    p_gte = 1 - p_lte
+    rp = 1 / p_gte
+
+    return rp
+
+
+def lp3_rv(rp, params, est_method="usgs"):
+    est_method = est_method.lower()
+    if est_method not in ["usgs", "lmoments", "scipy"]:
+        raise ValueError(
+            "Invalid method. Choose 'usgs' or 'lmoments' or 'scipy'."
+        )
+    rp_exceedance = [1 / rp for rp in rp]
+
+    if est_method == "usgs":
+        g = params["g"]
+        mu = params["mu"]
+        stdev = params["sd"]
+
+        q_rp_norm = norm.ppf(
+            1 - np.array(rp_exceedance), loc=0, scale=1
+        )  # Normal quantiles
+        k_rp = (2 / g) * (
+            ((q_rp_norm - (g / 6)) * (g / 6) + 1) ** 3 - 1
+        )  # Skewness adjustment
+        y_fit_rp = mu + k_rp * stdev  # Fitted values for return periods
+        ret = 10 ** (y_fit_rp)
+        # return return_value_lp3_usgs(x, rp)
+    elif est_method == "lmoments":
+        quantile = distr.pe3.ppf(1 - np.array(rp_exceedance), **params)
+        # quantile = distr.pe3.isf(rp_exceedance, **params)
+        ret = 10 ** (quantile)
+    elif est_method == "scipy":
+        quantile = pearson3.ppf(1 - np.array(rp_exceedance), *params)
+        ret = 10 ** (quantile)
+        # pass
+
+    return ret

--- a/src/utils/return_periods.py
+++ b/src/utils/return_periods.py
@@ -35,9 +35,7 @@ def lp3_params_all(group):
 
 
 def lp3_rp(x, params, est_method="lmoments"):
-    # Log-transform the data
     x = np.asarray(x)
-    # x[x <= 0] = np.min(x[x > 0])
     x_sorted = np.sort(x)
     x_log = np.log(x_sorted)
 
@@ -77,6 +75,23 @@ def lp3_rp(x, params, est_method="lmoments"):
 
 
 def lp3_rv(rp, params, est_method="usgs"):
+    """
+    Calculate return values for given return periods using the Log-Pearson Type III distribution.
+
+    Parameters:
+    rp (list or array-like): List of return periods.
+    params (dict or tuple): Parameters for the distribution.
+        - For 'usgs' method, a dictionary with keys 'g' (skewness), 'mu' (mean), and 'sd' (standard deviation).
+        - For 'lmoments' method, a dictionary with parameters for the Pearson Type III distribution.
+        - For 'scipy' method, a tuple with parameters for the Pearson Type III distribution.
+    est_method (str, optional): Method to estimate the return values. Options are 'usgs', 'lmoments', or 'scipy'. Default is 'usgs'.
+
+    Returns:
+    numpy.ndarray: Return values corresponding to the given return periods.
+
+    Raises:
+    ValueError: If an invalid estimation method is provided.
+    """
     est_method = est_method.lower()
     if est_method not in ["usgs", "lmoments", "scipy"]:
         raise ValueError(
@@ -99,12 +114,10 @@ def lp3_rv(rp, params, est_method="usgs"):
         ret = 10 ** (y_fit_rp)
         # return return_value_lp3_usgs(x, rp)
     elif est_method == "lmoments":
-        quantile = distr.pe3.ppf(1 - np.array(rp_exceedance), **params)
-        # quantile = distr.pe3.isf(rp_exceedance, **params)
-        ret = 10 ** (quantile)
+        value_log = distr.pe3.ppf(1 - np.array(rp_exceedance), **params)
+        ret = 10 ** (value_log)
     elif est_method == "scipy":
-        quantile = pearson3.ppf(1 - np.array(rp_exceedance), *params)
-        ret = 10 ** (quantile)
-        # pass
+        value_log = pearson3.ppf(1 - np.array(rp_exceedance), *params)
+        ret = 10 ** (value_log)
 
     return ret

--- a/src/utils/return_periods.py
+++ b/src/utils/return_periods.py
@@ -1,0 +1,165 @@
+import pandas as pd
+import numpy as np
+from scipy.stats import skew, norm, pearson3
+from lmoments3 import distr, lmom_ratios
+
+
+def params_lp3_usgs(x, imputation_method="lowest"):
+    """
+    Calculate the parameters for the Log-Pearson Type III distribution using USGS method.
+
+    Parameters:
+    x (array-like): Array of observed data.
+    imputation_method (str): Method for handling non-positive values in the data. Default is "lowest".
+
+    Returns:
+    dict: Dictionary containing the mean (mu), standard deviation (sd), and skewness (g) of the log-transformed data.
+
+    Example:
+    >>> import numpy as np
+    >>> data = np.array([10, 20, 30, 40, 50])
+    >>> params_lp3_usgs(data)
+    {'mu': np.float64(1.415836249209525),'sd': np.float64(0.2759982424449524),'g': np.float64(-0.5854140744039718)}
+    """
+    if imputation_method == "lowest":
+        x = np.where(x <= 0, np.min(x[np.nonzero(x)]), x)
+    x_log = np.log10(x)
+    return {"mu": np.mean(x_log), "sd": np.std(x_log, ddof=1), "g": skew(x_log)}
+
+
+def return_value_lp3_usgs(x, return_period):
+    """
+    Calculate the Log-Pearson Type III return value for given return periods using USGS method.
+
+    Parameters:
+    x (array-like): Array of observed data.
+    return_period (float): Return period for which the quantile is calculated.
+
+    Returns:
+    float: return value for the given return period.
+
+    Example:
+    >>> import numpy as np
+    >>> data = np.array([10, 20, 30, 40, 50])
+    >>> return_value_lp3_usgs(data, 100)
+    np.float64(86.91377279516328)
+    """
+    params = params_lp3_usgs(x)
+    g = params["g"]
+    mu = params["mu"]
+    stdev = params["sd"]
+
+    rp_exceedance = 1 / return_period
+    q_rp_norm = norm.ppf(1 - rp_exceedance)  # Normal quantiles
+    k_rp = (2 / g) * (
+        ((q_rp_norm - (g / 6)) * (g / 6) + 1) ** 3 - 1
+    )  # Skewness adjustment
+    y_fit_rp = mu + k_rp * stdev  # Fitted values for return periods
+    quantiles_rp = 10**y_fit_rp
+    return quantiles_rp
+
+
+def return_period_lp3_lmom(x, params):
+    """
+    Calculate the return period for given data and Log-Pearson Type III parameters.
+
+    Args:
+        x (array-like): Array of observed data.
+        params (tuple): Parameters of the Log-Pearson Type III distribution.
+
+    Returns:
+        float: Return period.
+
+    Example:
+        >>> import numpy as np
+        >>> from lmoments3 import distr, lmom_ratios
+        >>> data = np.array([10, 20, 30, 40, 50])
+        >>> params = params_lp3_lmom(data)
+        >>> return_period_lp3_lmom(30, params)
+        np.float64(9.264029097369093)
+    """
+    # Calculate the cumulative distribution function (CDF) value
+    p_lte = distr.pe3.cdf(x, **params)
+    p_gte = 1 - p_lte
+    rp = 1 / p_gte
+    return rp
+
+
+def params_lp3_lmom(x):
+    """
+    Calculate the parameters for the Log-Pearson Type III distribution using L-moments.
+
+    Args:
+        x (array-like): Array of observed data.
+
+    Returns:
+        dict: Dictionary containing the parameters of the Log-Pearson Type III distribution.
+    Examples:
+        >>> import numpy as np
+        >>> from return_periods import lp3_params_lmom
+        >>> data = np.array([1.2, 2.3, 3.4, 4.5, 5.6])
+        >>> params = lp3_params_lmom(data)
+        >>> print(params)
+        OrderedDict({'skew': 3.9736810031063223, 'loc': np.float64(1.125), 'scale': np.float64(2.459845871608456)})
+    """
+
+    # Compute L-moments
+    lmom = lmom_ratios(x, nmom=4)
+    # Fit the Log-Pearson Type III distribution using L-moments
+    params = distr.pe3.lmom_fit(lmom)
+    return params
+
+
+def return_value_lp3_lmom(x, return_period, params):
+    """
+    Calculate the Log-Pearson Type III return value for given return periods using L-moments.
+
+    Args:
+        x (array-like): Array of observed data.
+        return_period (float): Return period for which the quantile is calculated.
+        params (tuple): Parameters of the Log-Pearson Type III distribution.
+
+    Returns:
+        float: Return value for the given return period.
+
+    Example:
+        >>> import numpy as np
+        >>> data = np.array([10, 20, 30, 40, 50])
+        >>> params = params_lp3_lmom(data)
+        >>> return_value_lp3_lmom(data, 100, params)
+        np.float64(86.91377279516328)
+    """
+    rp_exceedance = 1 / return_period
+    quantile = distr.pe3.isf(rp_exceedance, **params)
+    return quantile
+
+
+def return_value(x, return_period, method="usgs"):
+    """
+    Calculate the return value for given return periods using specified method.
+
+    Parameters:
+    x (array-like): Array of observed data.
+    return_period (float): Return period for which the quantile is calculated.
+    method (str): Method to use for calculation ("usgs" or "lmom"). Default is "usgs".
+
+    Returns:
+    float: Return value for the given return period.
+
+    Example:
+    >>> import numpy as np
+    >>> data = np.array([10, 20, 30, 40, 50])
+    >>> return_value(data, 100, method="usgs")
+    np.float64(86.91377279516328)
+    >>> return_value(data, 100, method="lmom")
+    np.float64(86.91377279516328)
+    """
+    method = method.lower()
+    if method not in ["usgs", "lmom"]:
+        raise ValueError("Invalid method. Choose 'usgs' or 'lmom'.")
+
+    if method == "usgs":
+        return return_value_lp3_usgs(x, return_period)
+    elif method == "lmom":
+        params = params_lp3_lmom(x)
+        return return_value_lp3_lmom(x, return_period, params)


### PR DESCRIPTION
Implement Log Pearson III RP/RV calculations which we will use for FloodScan tabular dataset.

I wrote a `return_periods.py` module to hold the functions and then created an exploratory `.py` script that can be opened w/ jupytext to show how one might implement the functions.

More theoretical background on RP methods can be found [here](https://rpubs.com/zackarno/floodscan_rp_methods).

I'm not sure if this will end up being put on this repo in the final pipeline, but will still do the PR so that the calculations themselves can be reviewed by @t-downing . Also tagging @hannahker & @isatotun  to think/recommend how we'd actually orchestrate implementation.