### PR TITLE
Create `polygon` metadata table

### DIFF
--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -116,16 +116,10 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url):
 
 if __name__ == "__main__":
     args = cli_args()
-    dataset = args.dataset
-    logger.info(f"Updating data for {dataset}...")
 
     engine_url = db_engine_url(args.mode)
     engine = create_engine(engine_url)
 
-    create_qa_table(engine)
-    settings = load_pipeline_config(dataset)
-    start, end, is_forecast = parse_pipeline_config(settings, args.test)
-    create_dataset_table(dataset, engine, is_forecast)
     if args.update_metadata:
         logger.info("Updating metadata in Postgres database...")
         create_iso3_df(engine)
@@ -136,6 +130,14 @@ if __name__ == "__main__":
             sel_iso3s=None,
         )
         sys.exit(0)
+
+    dataset = args.dataset
+    logger.info(f"Updating data for {dataset}...")
+
+    create_qa_table(engine)
+    settings = load_pipeline_config(dataset)
+    start, end, is_forecast = parse_pipeline_config(settings, args.test)
+    create_dataset_table(dataset, engine, is_forecast)
 
     sel_iso3s = settings["test"]["iso3s"] if args.test else None
     df_iso3s = get_iso3_data(sel_iso3s, engine)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-
+UPSAMPLED_RESOLUTION = 0.05
 LOG_LEVEL = "INFO"
 AZURE_DB_PW_DEV = os.getenv("AZURE_DB_PW_DEV")
 AZURE_DB_PW_PROD = os.getenv("AZURE_DB_PW_PROD")

--- a/src/utils/database_utils.py
+++ b/src/utils/database_utils.py
@@ -131,6 +131,55 @@ def create_iso3_table(engine):
     metadata.create_all(engine)
 
 
+def create_polygon_table(engine, datasets):
+    """
+    Create a table for storing polygon metadata in the database.
+
+    Parameters
+    ----------
+    engine : sqlalchemy.engine.Engine
+        The SQLAlchemy engine object used to connect to the database.
+    datasets : list of str
+        List of dataset names to include in the table structure.
+
+    Returns
+    -------
+    None
+    """
+    columns = [
+        Column("pcode", String),
+        Column("iso3", CHAR(3)),
+        Column("adm_level", Integer),
+        Column("name", String),
+        Column("name_language", String),
+        Column("area", REAL),
+    ]
+
+    for dataset in datasets:
+        columns.extend(
+            [
+                Column(f"{dataset}_n_intersect_raw_pixels", Integer),
+                Column(f"{dataset}_frac_raw_pixels", REAL),
+                Column(f"{dataset}_n_upsampled_pixels", Integer),
+            ]
+        )
+
+    metadata = MetaData()
+    Table(
+        "polygon",
+        metadata,
+        *columns,
+        UniqueConstraint(
+            *["pcode", "iso3", "adm_level"],
+            name="polygon_valid_date_leadtime_pcode_key",
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+
+    metadata.create_all(engine)
+    return
+
+
 def insert_qa_table(iso3, adm_level, dataset, error, stack_trace, engine):
     """
     Insert an error record into the 'qa' table in the database.

--- a/src/utils/database_utils.py
+++ b/src/utils/database_utils.py
@@ -153,6 +153,7 @@ def create_polygon_table(engine, datasets):
         Column("name", String),
         Column("name_language", String),
         Column("area", REAL),
+        Column("standard", Boolean),
     ]
 
     for dataset in datasets:

--- a/src/utils/inputs.py
+++ b/src/utils/inputs.py
@@ -28,7 +28,7 @@ def cli_args():
     )
     parser.add_argument(
         "--update-metadata",
-        help="Update the polygon metadata table.",
+        help="Update the iso3 and polygon metadata tables.",
         action="store_true",
     )
     return parser.parse_args()

--- a/src/utils/inputs.py
+++ b/src/utils/inputs.py
@@ -11,6 +11,7 @@ def cli_args():
         help="Dataset for which to calculate raster stats",
         choices=["seas5", "era5", "imerg"],
         default=None,
+        nargs="?",
     )
     parser.add_argument(
         "--mode",

--- a/src/utils/inputs.py
+++ b/src/utils/inputs.py
@@ -26,8 +26,8 @@ def cli_args():
         action="store_true",
     )
     parser.add_argument(
-        "--build-iso3",
-        help="""Builds the `iso3` table in Postgres""",
+        "--update-metadata",
+        help="Update the polygon metadata table.",
         action="store_true",
     )
     return parser.parse_args()

--- a/src/utils/iso3_utils.py
+++ b/src/utils/iso3_utils.py
@@ -187,9 +187,11 @@ def create_iso3_df(engine):
     df["max_adm_level"] = df.apply(determine_max_adm_level, axis=1)
     df["stats_last_updated"] = None
 
+    # TODO: This list seems to have some inconsistencies when compared against the
+    # contents of all polygons
     # Also need global p-codes list from https://fieldmaps.io/data/cod
     # We want to get the total number of pcodes per iso3, across each admin level
-    df_pcodes = pd.read_csv("data/global-pcodes.csv")
+    df_pcodes = pd.read_csv("data/global-pcodes.csv", low_memory=False)
     df_pcodes.drop(df_pcodes.index[0], inplace=True)
     df_counts = (
         df_pcodes.groupby(["Location", "Admin Level"])["P-Code"]

--- a/src/utils/metadata_utils.py
+++ b/src/utils/metadata_utils.py
@@ -81,7 +81,7 @@ def calculate_polygon_stats(
         raster=dataset_data,
         affine=dataset_transform,
         nodata=np.nan,
-        all_touched=True,
+        all_touched=False,
         stats=["unique", "count"],
     )
 
@@ -220,6 +220,7 @@ def process_polygon_metadata(engine, mode, upsampled_resolution, sel_iso3s=None)
                     gdf["adm_level"] = i
                     gdf["name_language"] = name_column[-2:]
                     gdf["iso3"] = iso3
+                    gdf["standard"] = True
 
                     gdf.to_sql(
                         "polygon",

--- a/src/utils/metadata_utils.py
+++ b/src/utils/metadata_utils.py
@@ -221,9 +221,6 @@ def process_polygon_metadata(engine, mode, upsampled_resolution, sel_iso3s=None)
                     gdf["name_language"] = name_column[-2:]
                     gdf["iso3"] = iso3
 
-                    print(gdf.head(5))
-                    gdf.to_csv("test.csv")
-
                     gdf.to_sql(
                         "polygon",
                         con=engine,

--- a/src/utils/metadata_utils.py
+++ b/src/utils/metadata_utils.py
@@ -1,0 +1,236 @@
+import logging
+import tempfile
+from pathlib import Path
+
+import coloredlogs
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from rasterio.enums import Resampling
+from rasterstats import zonal_stats
+
+from src.config.settings import LOG_LEVEL
+from src.utils.cog_utils import stack_cogs
+from src.utils.database_utils import create_polygon_table, postgres_upsert
+from src.utils.iso3_utils import get_iso3_data, load_shp_from_azure
+
+logger = logging.getLogger(__name__)
+coloredlogs.install(level=LOG_LEVEL, logger=logger)
+
+
+def get_available_datasets():
+    """
+    Get list of available datasets from config directory.
+
+    Returns
+    -------
+    List[str]
+        List of dataset names (based on config file names)
+    """
+    config_dir = Path("src") / "config"
+    return [f.stem for f in config_dir.glob("*.yml")]
+
+
+def select_name_column(df, adm_level):
+    """
+    Select the appropriate name column from the administrative boundary GeoDataFrame.
+
+    Parameters
+    ----------
+    df : geopandas.GeoDataFrame
+        The GeoDataFrame containing administrative boundary data.
+    adm_level : int
+        The administrative level to find the name column for.
+
+    Returns
+    -------
+    str
+        The name of the selected column.
+    """
+    pattern = f"^ADM{adm_level}_[A-Z]{{2}}$"
+    adm_columns = df.filter(regex=pattern).columns
+    return adm_columns[0]
+
+
+def calculate_polygon_stats(
+    gdf, dataset_name, dataset_data, dataset_transform, upscale_factor
+):
+    """
+    Calculate polygon statistics for a specific dataset.
+
+    Parameters
+    ----------
+    gdf : geopandas.GeoDataFrame
+        The GeoDataFrame containing polygon geometries.
+    dataset_name : str
+        The name of the dataset.
+    dataset_data : numpy.ndarray
+        The raster data array for the dataset.
+    dataset_transform : affine.Affine
+        The affine transform for the raster data.
+    upscale_factor : float
+        The factor by which the raster has been upsampled.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing polygon statistics for the dataset.
+    """
+    stats = zonal_stats(
+        vectors=gdf[["geometry"]],
+        raster=dataset_data,
+        affine=dataset_transform,
+        nodata=np.nan,
+        all_touched=True,
+        stats=["unique", "count"],
+    )
+
+    df_out = pd.DataFrame.from_dict(stats)
+    df_out[f"{dataset_name}_frac_raw_pixels"] = df_out["count"] / (upscale_factor**2)
+    df_out = df_out.rename(
+        columns={
+            "unique": f"{dataset_name}_n_intersect_raw_pixels",
+            "count": f"{dataset_name}_n_upsampled_pixels",
+        }
+    )
+    return df_out
+
+
+def prepare_dataset_raster(dataset, start_date, end_date, upsampled_resolution):
+    """
+    Prepare raster data for a specific dataset.
+
+    Parameters
+    ----------
+    dataset : str
+        The name of the dataset to prepare.
+    start_date : str
+        Start date for the raster data.
+    end_date : str
+        End date for the raster data.
+    upsampled_resolution : float, optional
+        The desired output resolution after upsampling, by default 0.05.
+
+    Returns
+    -------
+    dict
+        Dictionary containing the prepared dataset information including data,
+        upscale factor, and transform.
+    """
+    ds = stack_cogs(start_date, end_date, dataset)
+    ds.values = np.arange(ds.size).reshape(ds.shape)
+    ds = ds.astype(np.float32)
+
+    if "leadtime" in ds.dims:
+        ds = ds.sel(leadtime=1)
+
+    input_resolution = ds.rio.resolution()[0]
+    upscale_factor = input_resolution / upsampled_resolution
+    new_width = int(ds.rio.width * upscale_factor)
+    new_height = int(ds.rio.height * upscale_factor)
+
+    ds_resampled = ds.rio.reproject(
+        ds.rio.crs,
+        shape=(new_height, new_width),
+        resampling=Resampling.nearest,
+        nodata=np.nan,
+    )
+
+    coords_transform = ds_resampled.rio.set_spatial_dims(
+        x_dim="x", y_dim="y"
+    ).rio.transform()
+
+    return {
+        "data": ds_resampled.values[0],
+        "upscale_factor": upscale_factor,
+        "transform": coords_transform,
+    }
+
+
+def process_polygon_metadata(engine, mode, upsampled_resolution, sel_iso3s=None):
+    """
+    Process and store polygon metadata for all administrative levels and datasets.
+
+    Parameters
+    ----------
+    engine : sqlalchemy.engine.Engine
+        The SQLAlchemy engine object used to connect to the database.
+    mode : str
+        The mode to run in ('dev', 'prod', etc.).
+    upsampled_resolution : float, optional
+        The desired output resolution for raster data.
+    sel_iso3s : list of str, optional
+        List of ISO3 codes to process. If None, processes all available.
+
+    Returns
+    -------
+    None
+    """
+    datasets = get_available_datasets()
+    create_polygon_table(engine, datasets)
+
+    dataset_info = {}
+    for dataset in datasets:
+        dataset_info[dataset] = prepare_dataset_raster(
+            dataset, "2024-01-01", "2024-01-01", upsampled_resolution
+        )
+
+    df_iso3s = get_iso3_data(sel_iso3s, engine)
+
+    with tempfile.TemporaryDirectory() as td:
+        for _, row in df_iso3s.iterrows():
+            iso3 = row["iso3"]
+            logger.info(f"Processing polygon metadata for {iso3}...")
+            max_adm = row["max_adm_level"]
+
+            load_shp_from_azure(iso3, td, mode)
+
+            for i in range(0, max_adm + 1):
+                try:
+                    gdf = gpd.read_file(f"{td}/{iso3.lower()}_adm{i}.shp")
+
+                    for dataset in datasets:
+                        df_stats = calculate_polygon_stats(
+                            gdf,
+                            dataset,
+                            dataset_info[dataset]["data"],
+                            dataset_info[dataset]["transform"],
+                            dataset_info[dataset]["upscale_factor"],
+                        )
+                        gdf = gdf.join(df_stats)
+
+                    # Calculate area in square kilometers
+                    gdf = gdf.to_crs("ESRI:54009")
+                    gdf["area"] = gdf.geometry.area / 1_000_000
+
+                    name_column = select_name_column(gdf, i)
+                    extract_cols = [f"ADM{i}_PCODE", name_column, "area"]
+                    dataset_cols = gdf.columns[
+                        gdf.columns.str.contains(
+                            "_n_intersect_raw_pixels|"
+                            "_frac_raw_pixels|"
+                            "_n_upsampled_pixels"
+                        )
+                    ]
+
+                    gdf = gdf[extract_cols + dataset_cols.tolist()]
+                    gdf = gdf.rename(
+                        columns={f"ADM{i}_PCODE": "pcode", name_column: "name"}
+                    )
+                    gdf["adm_level"] = i
+                    gdf["name_language"] = name_column[-2:]
+                    gdf["iso3"] = iso3
+
+                    print(gdf.head(5))
+                    gdf.to_csv("test.csv")
+
+                    gdf.to_sql(
+                        "polygon",
+                        con=engine,
+                        if_exists="append",
+                        index=False,
+                        method=postgres_upsert,
+                    )
+                except Exception as e:
+                    logger.error(f"Error processing {iso3} at ADM{i}: {str(e)}")
+                    continue

--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -8,7 +8,7 @@ import xarray as xr
 from rasterio.enums import Resampling
 from rasterio.features import rasterize
 
-from src.config.settings import LOG_LEVEL
+from src.config.settings import LOG_LEVEL, UPSAMPLED_RESOLUTION
 from src.utils.database_utils import postgres_upsert
 from src.utils.general_utils import add_months_to_date
 
@@ -204,7 +204,7 @@ def fast_zonal_stats(
     return feature_stats
 
 
-def upsample_raster(ds, resampled_resolution=0.05, logger=None):
+def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
     """
     Upsample a raster to a higher resolution using nearest neighbor resampling,
     via the `Resampling.nearest` method from `rasterio`.
@@ -214,7 +214,7 @@ def upsample_raster(ds, resampled_resolution=0.05, logger=None):
     ds : xarray.Dataset
         The raster data set to upsample. Must not have >4 dimensions.
     resampled_resolution : float, optional
-        The desired resolution for the upsampled raster. Default is 0.05.
+        The desired resolution for the upsampled raster.
 
     Returns
     -------

--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -193,6 +193,9 @@ def fast_zonal_stats(
             "sum": np.nansum,
             "std": np.nanstd,
             "count": lambda x, axis: np.sum(~np.isnan(x), axis=axis),
+            "unique": lambda x, axis: np.array(
+                [len(np.unique(row[~np.isnan(row)])) for row in x]
+            ),
         }
 
         for stat in stats:


### PR DESCRIPTION
Computing basic metadata about each polygon for which we're calculating summary stats. See [this Confluence page](https://humanitarian.atlassian.net/wiki/spaces/DSCI/pages/3927670786/public.polygon) for a description of each field. 

To do: 

- [x] Add Bool `standard` column to indicate if a polygon is a "standard" admin bound. Would be all True so far.