### PR TITLE
Fix upsampling

### DIFF
--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -255,7 +255,7 @@ def upsample_raster(ds, resampled_resolution=0.05, logger=None):
             ds_ = ds.sel(leadtime=lt)
             ds_ = ds_.rio.reproject(
                 ds_.rio.crs,
-                shape=(ds_.rio.height * 2, ds_.rio.width * 2),
+                shape=(new_height, new_width),
                 resampling=Resampling.nearest,
                 nodata=np.nan,
             )


### PR DESCRIPTION
Not sure how this happened, but the resampling for input datasets with >3 dims (ie. SEAS5) was not correct. I'll need to rerun all SEAS5 stats on `prod` to fix the outputs. 