### PR TITLE
Floodscan stats

### DIFF
--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -45,7 +45,7 @@ def setup_logger(name, level=logging.INFO):
     return logger
 
 
-def process_chunk(start, end, dataset, mode, df_iso3s, engine_url):
+def process_chunk(start, end, dataset, mode, df_iso3s, engine_url, chunksize):
     process_name = current_process().name
     logger = setup_logger(f"{process_name}: {dataset}_{start}")
     logger.info(f"Starting processing for {dataset} from {start} to {end}")
@@ -100,7 +100,7 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url):
                         con=engine,
                         if_exists="append",
                         index=False,
-                        chunksize=1000,
+                        chunksize=chunksize,
                         method=postgres_upsert,
                     )
                 except Exception as e:
@@ -151,7 +151,7 @@ if __name__ == "__main__":
         )
 
         process_args = [
-            (start, end, dataset, args.mode, df_iso3s, engine_url)
+            (start, end, dataset, args.mode, df_iso3s, engine_url, args.chunksize)
             for start, end in date_ranges
         ]
 
@@ -160,6 +160,6 @@ if __name__ == "__main__":
 
     else:
         logger.info("Processing entire date range in a single chunk")
-        process_chunk(start, end, dataset, args.mode, df_iso3s, engine_url)
+        process_chunk(start, end, dataset, args.mode, df_iso3s, engine_url, args.chunksize)
 
     logger.info("Done calculating and saving stats.")

--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -130,10 +130,10 @@ if __name__ == "__main__":
     logger.info(f"Updating data for {dataset}...")
 
     create_qa_table(engine)
-    start, end, is_forecast, sel_iso3s = parse_pipeline_config(
+    start, end, is_forecast, sel_iso3s, extra_dims = parse_pipeline_config(
         dataset, args.test, args.update_stats, args.mode
     )
-    create_dataset_table(dataset, engine, is_forecast)
+    create_dataset_table(dataset, engine, is_forecast, extra_dims)
 
     df_iso3s = get_iso3_data(sel_iso3s, engine)
     date_ranges = split_date_range(start, end)

--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -57,6 +57,12 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url):
         for _, row in df_iso3s.iterrows():
             iso3 = row["iso3"]
             max_adm = row["max_adm_level"]
+
+            # Coverage check for specific datasets
+            if dataset in df_iso3s.keys() :
+                if not row[dataset]:
+                    logger.info(f"Skipping {iso3}...")
+                    continue
             logger.info(f"Processing data for {iso3}...")
 
             with tempfile.TemporaryDirectory() as td:

--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -117,8 +117,8 @@ if __name__ == "__main__":
 
     create_qa_table(engine)
     settings = load_pipeline_config(dataset)
-    start, end, is_forecast = parse_pipeline_config(settings, args.test)
-    create_dataset_table(dataset, engine, is_forecast)
+    start, end, is_forecast, extra_dims = parse_pipeline_config(settings, args.test)
+    create_dataset_table(dataset, engine, is_forecast, extra_dims)
     if args.build_iso3:
         logger.info("Creating ISO3 table in Postgres database...")
         create_iso3_df(engine)

--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -55,7 +55,6 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url):
     try:
         for _, row in df_iso3s.iterrows():
             iso3 = row["iso3"]
-            # shp_url = row["o_shp"]
             max_adm = row["max_adm_level"]
             logger.info(f"Processing data for {iso3}...")
 

--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -59,7 +59,7 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url, chunksize):
             max_adm = row["max_adm_level"]
 
             # Coverage check for specific datasets
-            if dataset in df_iso3s.keys() :
+            if dataset in df_iso3s.keys():
                 if not row[dataset]:
                     logger.info(f"Skipping {iso3}...")
                     continue
@@ -160,6 +160,8 @@ if __name__ == "__main__":
 
     else:
         logger.info("Processing entire date range in a single chunk")
-        process_chunk(start, end, dataset, args.mode, df_iso3s, engine_url, args.chunksize)
+        process_chunk(
+            start, end, dataset, args.mode, df_iso3s, engine_url, args.chunksize
+        )
 
     logger.info("Done calculating and saving stats.")

--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -100,6 +100,7 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url):
                         con=engine,
                         if_exists="append",
                         index=False,
+                        chunksize=1000,
                         method=postgres_upsert,
                     )
                 except Exception as e:

--- a/src/config/floodscan.yml
+++ b/src/config/floodscan.yml
@@ -1,4 +1,4 @@
-blob_prefix: floodscan/daily/v5/processed/aer__area_300s_
+blob_prefix: floodscan/daily/v5/processed/aer_area_300s_
 start_date: 1998-01-12
 end_date: Null
 forecast: False
@@ -6,5 +6,5 @@ extra_dims:
   - band
 test:
   start_date: 2023-12-01
-  end_date: 2023-12-05
+  end_date: 2024-01-31
   iso3s: ["ETH"]

--- a/src/config/floodscan.yml
+++ b/src/config/floodscan.yml
@@ -3,7 +3,7 @@ start_date: 1998-01-12
 end_date: Null
 forecast: False
 extra_dims:
-  - band
+  - band : str
 test:
   start_date: 2023-12-01
   end_date: 2024-01-31

--- a/src/config/floodscan.yml
+++ b/src/config/floodscan.yml
@@ -1,5 +1,5 @@
 blob_prefix: floodscan/daily/v5/processed/aer_area_300s_
-start_date: 2023-01-01
+start_date: 1998-01-12
 end_date: Null
 forecast: False
 extra_dims:

--- a/src/config/floodscan.yml
+++ b/src/config/floodscan.yml
@@ -1,0 +1,8 @@
+blob_prefix: floodscan/daily/v5/processed/aer__area_300s_
+start_date: 1998-01-12
+end_date: Null
+forecast: False
+test:
+  start_date: 2023-12-01
+  end_date: 2023-12-05
+  iso3s: ["ETH"]

--- a/src/config/floodscan.yml
+++ b/src/config/floodscan.yml
@@ -1,5 +1,5 @@
 blob_prefix: floodscan/daily/v5/processed/aer_area_300s_
-start_date: 1998-01-12
+start_date: 2023-01-01
 end_date: Null
 forecast: False
 extra_dims:

--- a/src/config/floodscan.yml
+++ b/src/config/floodscan.yml
@@ -2,6 +2,8 @@ blob_prefix: floodscan/daily/v5/processed/aer__area_300s_
 start_date: 1998-01-12
 end_date: Null
 forecast: False
+extra_dims:
+  - band
 test:
   start_date: 2023-12-01
   end_date: 2023-12-05

--- a/src/config/floodscan.yml
+++ b/src/config/floodscan.yml
@@ -8,3 +8,4 @@ test:
   start_date: 2023-12-01
   end_date: 2024-01-31
   iso3s: ["ETH"]
+coverage: ["DZA", "AGO", "BEN", "BWA", "BFA", "BDI", "CPV", "CMR", "CAF", "TCD", "COM", "COG", "CIV", "CAP", "DJI", "EGY", "GNQ", "ERI", "SWZ", "ETH", "GAB", "GMB", "GHA", "GIN", "GNB", "KEN", "LS0", "LBR", "LBY", "MDG", "MWI", "MLI", "MRT", "MUS", "MAR", "MOZ", "NAM", "NER", "NGA", "RWA", "STP", "SEN", "SYC", "SLE", "SOM", "ZAF", "SSD", "SDN", "TGO", "TUN", "UGA", "TZA", "ZMB", "ZWE"]

--- a/src/config/imerg.yml
+++ b/src/config/imerg.yml
@@ -3,6 +3,6 @@ start_date: 2000-06-01
 end_date: 2024-10-30
 forecast: False
 test:
-  start_date: 2000-06-01
-  end_date: 2024-10-01
+  start_date: 2020-01-01
+  end_date: 2020-01-15
   iso3s: ["ETH"]

--- a/src/config/imerg.yml
+++ b/src/config/imerg.yml
@@ -4,5 +4,5 @@ end_date: 2024-10-30
 forecast: False
 test:
   start_date: 2000-06-01
-  end_date: 2002-01-15
-  iso3s: ["AFG", "ETH", "HTI", "LBN"]
+  end_date: 2024-10-01
+  iso3s: ["ETH"]

--- a/src/config/seas5.yml
+++ b/src/config/seas5.yml
@@ -3,7 +3,7 @@ start_date: 1981-01-01
 end_date: Null
 forecast: True
 extra_dims:
-  - leadtime
+  - leadtime : int
 test:
   start_date: 2024-01-01
   end_date: 2024-02-01

--- a/src/config/seas5.yml
+++ b/src/config/seas5.yml
@@ -2,7 +2,9 @@ blob_prefix: seas5/monthly/processed/precip_em_i
 start_date: 1981-01-01
 end_date: 2024-10-30
 forecast: True
+extra_dims:
+  - leadtime
 test:
-  start_date: 2012-01-01
-  end_date: 2024-10-01
-  iso3s: []
+  start_date: 2024-01-01
+  end_date: 2024-02-01
+  iso3s: ["AFG"]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -3,7 +3,7 @@ from datetime import date, timedelta
 
 import yaml
 from dotenv import load_dotenv
-from sqlalchemy import Integer, VARCHAR
+from sqlalchemy import VARCHAR, Integer
 
 from src.utils.general_utils import get_most_recent_date
 
@@ -26,13 +26,13 @@ def load_pipeline_config(pipeline_name):
         config = yaml.safe_load(config_file)
     return config
 
- # TODO shift this to some utils?
-def parse_extra_dims(extra_dims):
 
+# TODO shift this to some utils?
+def parse_extra_dims(extra_dims):
     parsed_extra_dims = {}
     for extra_dim in extra_dims:
         dim = next(iter(extra_dim))
-        if extra_dim[dim] == 'str':
+        if extra_dim[dim] == "str":
             parsed_extra_dims[dim] = VARCHAR
         else:
             parsed_extra_dims[dim] = Integer

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -31,4 +31,5 @@ def parse_pipeline_config(config, test):
         start_date = config["start_date"]
         end_date = config["end_date"]
     forecast = config["forecast"]
-    return start_date, end_date, forecast
+    extra_dims = config.get("extra_dims", [])
+    return start_date, end_date, forecast, extra_dims

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 
 import yaml
 from dotenv import load_dotenv
+from sqlalchemy import Integer, VARCHAR
 
 from src.utils.general_utils import get_most_recent_date
 
@@ -25,6 +26,19 @@ def load_pipeline_config(pipeline_name):
         config = yaml.safe_load(config_file)
     return config
 
+ # TODO shift this to some utils?
+def parse_extra_dims(extra_dims):
+
+    parsed_extra_dims = {}
+    for extra_dim in extra_dims:
+        dim = next(iter(extra_dim))
+        if extra_dim[dim] == 'str':
+            parsed_extra_dims[dim] = VARCHAR
+        else:
+            parsed_extra_dims[dim] = Integer
+
+    return parsed_extra_dims
+
 
 def parse_pipeline_config(dataset, test, update, mode):
     config = load_pipeline_config(dataset)
@@ -37,7 +51,7 @@ def parse_pipeline_config(dataset, test, update, mode):
         end_date = config["end_date"]
         sel_iso3s = None
     forecast = config["forecast"]
-    extra_dims = config.get("extra_dims", [])
+    extra_dims = parse_extra_dims(config.get("extra_dims"))
     if not end_date:
         end_date = date.today() - timedelta(days=1)
     if update:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -3,9 +3,8 @@ from datetime import date, timedelta
 
 import yaml
 from dotenv import load_dotenv
-from sqlalchemy import VARCHAR, Integer
 
-from src.utils.general_utils import get_most_recent_date
+from src.utils.general_utils import get_most_recent_date, parse_extra_dims
 
 load_dotenv()
 
@@ -25,19 +24,6 @@ def load_pipeline_config(pipeline_name):
     with open(config_path, "r") as config_file:
         config = yaml.safe_load(config_file)
     return config
-
-
-# TODO shift this to some utils?
-def parse_extra_dims(extra_dims):
-    parsed_extra_dims = {}
-    for extra_dim in extra_dims:
-        dim = next(iter(extra_dim))
-        if extra_dim[dim] == "str":
-            parsed_extra_dims[dim] = VARCHAR
-        else:
-            parsed_extra_dims[dim] = Integer
-
-    return parsed_extra_dims
 
 
 def parse_pipeline_config(dataset, test, update, mode):

--- a/src/utils/cloud_utils.py
+++ b/src/utils/cloud_utils.py
@@ -42,9 +42,9 @@ def get_container_client(mode, container_name):
     )
     TODO add back
     """
-    blob_sas = os.getenv(f"DSCI_AZ_SAS_DEV")
+    blob_sas = os.getenv(f"DSCI_AZ_SAS_PROD")
     blob_url = (
-            f"https://imb0chd0dev.blob.core.windows.net/"
+            f"https://imb0chd0prod.blob.core.windows.net/"
             + container_name  # noqa
             + "?"  # noqa
             + blob_sas  # noqa
@@ -74,5 +74,5 @@ def get_cog_url(mode, cog_name):
         return "test_outputs/" + cog_name
     #TODO add back blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
     #return f"https://imb0chd0{mode}.blob.core.windows.net/raster/{cog_name}?{blob_sas}"
-    blob_sas = os.getenv(f"DSCI_AZ_SAS_DEV")
-    return f"https://imb0chd0dev.blob.core.windows.net/raster/{cog_name}?{blob_sas}"
+    blob_sas = os.getenv(f"DSCI_AZ_SAS_PROD")
+    return f"https://imb0chd0prod.blob.core.windows.net/raster/{cog_name}?{blob_sas}"

--- a/src/utils/cloud_utils.py
+++ b/src/utils/cloud_utils.py
@@ -32,19 +32,10 @@ def get_container_client(mode, container_name):
         + "?"  # noqa
         + blob_sas  # noqa
     )
-
+    """
     blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
     blob_url = (
             f"https://imb0chd0{mode}.blob.core.windows.net/"
-            + container_name  # noqa
-            + "?"  # noqa
-            + blob_sas  # noqa
-    )
-    TODO add back
-    """
-    blob_sas = os.getenv(f"DSCI_AZ_SAS_PROD")
-    blob_url = (
-            f"https://imb0chd0prod.blob.core.windows.net/"
             + container_name  # noqa
             + "?"  # noqa
             + blob_sas  # noqa
@@ -72,7 +63,5 @@ def get_cog_url(mode, cog_name):
     """
     if mode == "local":
         return "test_outputs/" + cog_name
-    #TODO add back blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
-    #return f"https://imb0chd0{mode}.blob.core.windows.net/raster/{cog_name}?{blob_sas}"
-    blob_sas = os.getenv(f"DSCI_AZ_SAS_PROD")
-    return f"https://imb0chd0prod.blob.core.windows.net/raster/{cog_name}?{blob_sas}"
+    blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
+    return f"https://imb0chd0{mode}.blob.core.windows.net/raster/{cog_name}?{blob_sas}"

--- a/src/utils/cloud_utils.py
+++ b/src/utils/cloud_utils.py
@@ -24,13 +24,21 @@ def get_container_client(mode, container_name):
     azure.storage.blob.ContainerClient
         A `ContainerClient` object that can be used to interact with the specified Azure Blob Storage container
 
-    """
+
     blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
     blob_url = (
         f"https://imb0chd0{mode}.blob.core.windows.net/"
         + container_name  # noqa
         + "?"  # noqa
         + blob_sas  # noqa
+    )
+    """
+    blob_sas = os.getenv(f"DSCI_AZ_SAS_PROD")
+    blob_url = (
+            f"https://imb0chd0prod.blob.core.windows.net/"
+            + container_name  # noqa
+            + "?"  # noqa
+            + blob_sas  # noqa
     )
     return ContainerClient.from_container_url(blob_url)
 
@@ -55,5 +63,7 @@ def get_cog_url(mode, cog_name):
     """
     if mode == "local":
         return "test_outputs/" + cog_name
-    blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
-    return f"https://imb0chd0{mode}.blob.core.windows.net/raster/{cog_name}?{blob_sas}"
+    #blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
+    #return f"https://imb0chd0{mode}.blob.core.windows.net/raster/{cog_name}?{blob_sas}"
+    blob_sas = os.getenv(f"DSCI_AZ_SAS_PROD")
+    return f"https://imb0chd0prod.blob.core.windows.net/raster/{cog_name}?{blob_sas}"

--- a/src/utils/cloud_utils.py
+++ b/src/utils/cloud_utils.py
@@ -32,10 +32,19 @@ def get_container_client(mode, container_name):
         + "?"  # noqa
         + blob_sas  # noqa
     )
-    """
-    blob_sas = os.getenv(f"DSCI_AZ_SAS_PROD")
+
+    blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
     blob_url = (
-            f"https://imb0chd0prod.blob.core.windows.net/"
+            f"https://imb0chd0{mode}.blob.core.windows.net/"
+            + container_name  # noqa
+            + "?"  # noqa
+            + blob_sas  # noqa
+    )
+    TODO add back
+    """
+    blob_sas = os.getenv(f"DSCI_AZ_SAS_DEV")
+    blob_url = (
+            f"https://imb0chd0dev.blob.core.windows.net/"
             + container_name  # noqa
             + "?"  # noqa
             + blob_sas  # noqa
@@ -63,7 +72,7 @@ def get_cog_url(mode, cog_name):
     """
     if mode == "local":
         return "test_outputs/" + cog_name
-    #blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
+    #TODO add back blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
     #return f"https://imb0chd0{mode}.blob.core.windows.net/raster/{cog_name}?{blob_sas}"
-    blob_sas = os.getenv(f"DSCI_AZ_SAS_PROD")
-    return f"https://imb0chd0prod.blob.core.windows.net/raster/{cog_name}?{blob_sas}"
+    blob_sas = os.getenv(f"DSCI_AZ_SAS_DEV")
+    return f"https://imb0chd0dev.blob.core.windows.net/raster/{cog_name}?{blob_sas}"

--- a/src/utils/cloud_utils.py
+++ b/src/utils/cloud_utils.py
@@ -24,21 +24,13 @@ def get_container_client(mode, container_name):
     azure.storage.blob.ContainerClient
         A `ContainerClient` object that can be used to interact with the specified Azure Blob Storage container
 
-
+    """
     blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
     blob_url = (
         f"https://imb0chd0{mode}.blob.core.windows.net/"
         + container_name  # noqa
         + "?"  # noqa
         + blob_sas  # noqa
-    )
-    """
-    blob_sas = os.getenv(f"DSCI_AZ_SAS_{mode.upper()}")
-    blob_url = (
-            f"https://imb0chd0{mode}.blob.core.windows.net/"
-            + container_name  # noqa
-            + "?"  # noqa
-            + blob_sas  # noqa
     )
     return ContainerClient.from_container_url(blob_url)
 

--- a/src/utils/cog_utils.py
+++ b/src/utils/cog_utils.py
@@ -211,6 +211,5 @@ def stack_cogs(start_date, end_date, dataset="era5", mode="dev"):
         das.append(da_in)
 
     # Note that we're dropping all attributes here
-    # ds = xr.combine_by_coords(das, combine_attrs="drop")
-    ds = xr.concat(das, dim="date")
+    ds = xr.combine_by_coords(das, combine_attrs="drop")
     return ds

--- a/src/utils/cog_utils.py
+++ b/src/utils/cog_utils.py
@@ -14,19 +14,6 @@ logger = logging.getLogger(__name__)
 coloredlogs.install(level="DEBUG", logger=logger)
 
 
-def parse_date(filename, dataset):
-    """
-    Parses the date based on a COG filename.
-    """
-    if (dataset == "era5") or (dataset == "imerg"):
-        date = pd.to_datetime(filename[-14:-4])
-    elif dataset == "seas5":
-        date = pd.to_datetime(filename[-18:-8])
-    else:
-        raise Exception("Input `dataset` must be one of: imerg, era5, seas5")
-    return pd.to_datetime(date)
-
-
 # TODO: Update now that IMERG data has the right .attrs metadata
 def process_imerg(cog_name, mode):
     """
@@ -184,8 +171,8 @@ def stack_cogs(start_date, end_date, dataset="era5", mode="dev"):
     cogs_list = [
         x.name
         for x in container_client.list_blobs(name_starts_with=prefix)
-        if (parse_date(x.name, dataset) >= start_date)
-        & (parse_date(x.name, dataset) <= end_date)  # noqa
+        if (parse_date(x.name) >= start_date)
+        & (parse_date(x.name) <= end_date)  # noqa
     ]
 
     if len(cogs_list) == 0:

--- a/src/utils/cog_utils.py
+++ b/src/utils/cog_utils.py
@@ -21,8 +21,10 @@ def parse_date(filename, dataset):
         date = pd.to_datetime(filename[-14:-4])
     elif dataset == "seas5":
         date = pd.to_datetime(filename[-18:-8])
+    elif dataset == "floodscan":
+        date = pd.to_datetime(filename[-21:-11])
     else:
-        raise Exception("Input `dataset` must be one of: imerg, era5, seas5")
+        raise Exception("Input `dataset` must be one of: floodscan, imerg, era5, seas5")
     return pd.to_datetime(date)
 
 
@@ -161,7 +163,9 @@ def stack_cogs(start_date, end_date, dataset="era5", mode="dev"):
         config = load_pipeline_config(dataset)
         prefix = config["blob_prefix"]
     except Exception:
-        logger.error("Input `dataset` must be one of `era5`, `seas5`, or `imerg`.")
+        logger.error(
+            "Input `dataset` must be one of `floodscan`, `era5`, `seas5`, or `imerg`."
+        )
 
     cogs_list = [
         x.name

--- a/src/utils/cog_utils.py
+++ b/src/utils/cog_utils.py
@@ -115,7 +115,7 @@ def process_floodscan(cog_name, mode):
 
     year_valid = da_in.attrs["year_valid"]
     month_valid = str(da_in.attrs["month_valid"]).zfill(2)
-    date_valid = cog_name[-13:-11]  # TODO: Change once attr is updated correctly
+    date_valid = str(da_in.attrs["date_valid"]).zfill(2)
     date_in = f"{year_valid}-{month_valid}-{date_valid}"
 
     da_in = da_in.squeeze(drop=True)
@@ -173,8 +173,7 @@ def stack_cogs(start_date, end_date, dataset="era5", mode="dev"):
     cogs_list = [
         x.name
         for x in container_client.list_blobs(name_starts_with=prefix)
-        if (parse_date(x.name) >= start_date)
-        & (parse_date(x.name) <= end_date)  # noqa
+        if (parse_date(x.name) >= start_date) & (parse_date(x.name) <= end_date)  # noqa
     ]
 
     if len(cogs_list) == 0:

--- a/src/utils/database_utils.py
+++ b/src/utils/database_utils.py
@@ -133,6 +133,7 @@ def create_iso3_table(engine):
         Column("max_adm_level", Integer),
         Column("stats_last_updated", Date),
         Column("shp_url", String),
+        Column("floodscan", Boolean),
     )
     metadata.create_all(engine)
 

--- a/src/utils/database_utils.py
+++ b/src/utils/database_utils.py
@@ -35,7 +35,7 @@ def db_engine_url(mode):
     return DATABASES[mode]
 
 
-def create_dataset_table(dataset, engine, is_forecast=False, extra_dims=[]):
+def create_dataset_table(dataset, engine, is_forecast=False, extra_dims={}):
     """
     Create a table for storing dataset statistics in the database.
 
@@ -48,16 +48,16 @@ def create_dataset_table(dataset, engine, is_forecast=False, extra_dims=[]):
     is_forecast : Bool
         Whether or not the dataset is a forecast. Will include `leadtime` and
         `issued_date` columns if so.
-    extra_dims : List
-        A list of the names of any extra dimensions that need to be added to the
-        dataset table.
+    extra_dims : dict
+        Dictionary where the keys are names of any extra dimensions that need to be added to the
+        dataset table and the values are the type.
 
     Returns
     -------
     None
     """
     if extra_dims is None:
-        extra_dims = []
+        extra_dims = {}
     metadata = MetaData()
     columns = [
         Column("iso3", CHAR(3)),
@@ -77,8 +77,7 @@ def create_dataset_table(dataset, engine, is_forecast=False, extra_dims=[]):
     if is_forecast:
         columns.insert(3, Column("issued_date", Date))
     for idx, dim in enumerate(extra_dims):
-        # TODO: Support non-integer columns
-        columns.insert(idx + 4, Column(dim, Integer))
+        columns.insert(idx + 4, Column(dim, extra_dims[dim]))
         unique_constraint_columns.append(dim)
 
     Table(

--- a/src/utils/database_utils.py
+++ b/src/utils/database_utils.py
@@ -35,7 +35,7 @@ def db_engine_url(mode):
     return DATABASES[mode]
 
 
-def create_dataset_table(dataset, engine, is_forecast=False, extra_dims=[]):
+def create_dataset_table(dataset, engine, is_forecast=False, extra_dims=None):
     """
     Create a table for storing dataset statistics in the database.
 
@@ -48,11 +48,14 @@ def create_dataset_table(dataset, engine, is_forecast=False, extra_dims=[]):
     is_forecast : Bool
         Whether or not the dataset is a forecast. Will include `leadtime` and
         `issued_date` columns if so.
-
+    extra_dims: List
+        List containing the name of the extra dimensions
     Returns
     -------
     None
     """
+    if extra_dims is None:
+        extra_dims = []
     metadata = MetaData()
     columns = [
         Column("iso3", CHAR(3)),

--- a/src/utils/database_utils.py
+++ b/src/utils/database_utils.py
@@ -35,7 +35,7 @@ def db_engine_url(mode):
     return DATABASES[mode]
 
 
-def create_dataset_table(dataset, engine, is_forecast=False):
+def create_dataset_table(dataset, engine, is_forecast=False, extra_dims=[]):
     """
     Create a table for storing dataset statistics in the database.
 
@@ -71,8 +71,10 @@ def create_dataset_table(dataset, engine, is_forecast=False):
     unique_constraint_columns = ["valid_date", "pcode"]
     if is_forecast:
         columns.insert(3, Column("issued_date", Date))
-        columns.insert(4, Column("leadtime", Integer))
-        unique_constraint_columns.append("leadtime")
+    for idx, dim in enumerate(extra_dims):
+        # TODO: Support non-integer columns
+        columns.insert(idx + 4, Column(dim, Integer))
+        unique_constraint_columns.append(dim)
 
     Table(
         f"{dataset}",

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 from dateutil.relativedelta import relativedelta
+from sqlalchemy import VARCHAR, Integer
 
 from src.utils.cloud_utils import get_container_client
 
@@ -110,3 +111,15 @@ def parse_date(filename):
     """
     res = re.search("([0-9]{4}-[0-9]{2}-[0-9]{2})", filename)
     return pd.to_datetime(res[0])
+
+
+def parse_extra_dims(extra_dims):
+    parsed_extra_dims = {}
+    for extra_dim in extra_dims:
+        dim = next(iter(extra_dim))
+        if extra_dim[dim] == "str":
+            parsed_extra_dims[dim] = VARCHAR
+        else:
+            parsed_extra_dims[dim] = Integer
+
+    return parsed_extra_dims

--- a/src/utils/inputs.py
+++ b/src/utils/inputs.py
@@ -9,7 +9,7 @@ def cli_args():
     parser.add_argument(
         "dataset",
         help="Dataset for which to calculate raster stats",
-        choices=["seas5", "era5", "imerg"],
+        choices=["seas5", "era5", "imerg", "floodscan"],
         default=None,
     )
     parser.add_argument(

--- a/src/utils/inputs.py
+++ b/src/utils/inputs.py
@@ -36,4 +36,10 @@ def cli_args():
         help="Update the iso3 and polygon metadata tables.",
         action="store_true",
     )
+    parser.add_argument(
+        "--chunksize",
+        help="Limit the SQL insert batches to an specific chunksize.",
+        type=int,
+        default=100000,
+    )
     return parser.parse_args()

--- a/src/utils/iso3_utils.py
+++ b/src/utils/iso3_utils.py
@@ -180,7 +180,7 @@ def create_iso3_df(engine):
     ]
 
     # TODO add info on how to retrieve this file
-    floodscan_iso3_coverage = pd.read_csv("data/floodscan_iso3s.csv")['iso3'].tolist()
+    floodscan_iso3_coverage = pd.read_csv("data/floodscan_iso3s.csv")["iso3"].tolist()
 
     iso3_codes = set()
     for locations in df_active_hrp["locations"]:

--- a/src/utils/iso3_utils.py
+++ b/src/utils/iso3_utils.py
@@ -8,6 +8,7 @@ import pandas as pd
 import requests
 from sqlalchemy import text
 
+from src.config.settings import load_pipeline_config
 from src.utils.cloud_utils import get_container_client
 from src.utils.database_utils import create_iso3_table
 
@@ -144,6 +145,19 @@ def determine_max_adm_level(row):
         return min(1, row["src_lvl"])
 
 
+def load_coverage():
+    pipelines = ["seas5", "era5", "imerg", "floodscan"]
+    coverage = {}
+
+    for dataset in pipelines:
+        config = load_pipeline_config(dataset)
+        if "coverage" in config:
+            dataset_coverage = config["coverage"]
+            coverage[dataset] = dataset_coverage
+
+    return coverage
+
+
 def create_iso3_df(engine):
     """
     Create and populate an ISO3 table in the database with country information.
@@ -178,9 +192,7 @@ def create_iso3_df(engine):
         )
         & (df_hrp["endDate"] >= current_date)  # noqa
     ]
-
-    # TODO add info on how to retrieve this file
-    floodscan_iso3_coverage = pd.read_csv("data/floodscan_iso3s.csv")["iso3"].tolist()
+    dataset_coverage = load_coverage()
 
     iso3_codes = set()
     for locations in df_active_hrp["locations"]:
@@ -190,7 +202,9 @@ def create_iso3_df(engine):
     df["has_active_hrp"] = df["iso_3"].isin(iso3_codes)
     df["max_adm_level"] = df.apply(determine_max_adm_level, axis=1)
     df["stats_last_updated"] = None
-    df["floodscan"] = df["iso_3"].isin(floodscan_iso3_coverage)
+
+    for dataset in dataset_coverage:
+        df[dataset] = df["iso_3"].isin(dataset_coverage[dataset])
 
     # TODO: This list seems to have some inconsistencies when compared against the
     # contents of all polygons

--- a/src/utils/iso3_utils.py
+++ b/src/utils/iso3_utils.py
@@ -178,6 +178,10 @@ def create_iso3_df(engine):
         )
         & (df_hrp["endDate"] >= current_date)  # noqa
     ]
+
+    # TODO add info on how to retrieve this file
+    floodscan_iso3_coverage = pd.read_csv("data/floodscan_iso3s.csv")['iso3'].tolist()
+
     iso3_codes = set()
     for locations in df_active_hrp["locations"]:
         iso3_codes.update(locations.split("|"))
@@ -186,6 +190,7 @@ def create_iso3_df(engine):
     df["has_active_hrp"] = df["iso_3"].isin(iso3_codes)
     df["max_adm_level"] = df.apply(determine_max_adm_level, axis=1)
     df["stats_last_updated"] = None
+    df["floodscan"] = df["iso_3"].isin(floodscan_iso3_coverage)
 
     # TODO: This list seems to have some inconsistencies when compared against the
     # contents of all polygons

--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -283,9 +283,9 @@ def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
                 # Falls under different bands, use the long_name instead of integer value
                 #ds_ = ds_.expand_dims({'band': [ds_.long_name[val-1]]})
                 if int(ds_['band']) ==1 :
-                    ds_ = ds_.expand_dims({'band': 'SFED'})
+                    ds_ = ds_.expand_dims({'band': ['SFED']})
                 else:
-                    ds_ = ds_.expand_dims({'band': 'MFED'})
+                    ds_ = ds_.expand_dims({'band': ['MFED']})
             else:
                 ds_ = ds_.expand_dims([fourth_dim])
             resampled_arrays.append(ds_)

--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -281,11 +281,10 @@ def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
             # Expand along the fourth dimension
             if fourth_dim == "band":
                 # Falls under different bands, use the long_name instead of integer value
-                #ds_ = ds_.expand_dims({'band': [ds_.long_name[val-1]]})
-                if int(ds_['band']) ==1 :
-                    ds_ = ds_.expand_dims({'band': ['SFED']})
+                if int(ds_["band"]) == 1:
+                    ds_ = ds_.expand_dims({"band": ["SFED"]})
                 else:
-                    ds_ = ds_.expand_dims({'band': ['MFED']})
+                    ds_ = ds_.expand_dims({"band": ["MFED"]})
             else:
                 ds_ = ds_.expand_dims([fourth_dim])
             resampled_arrays.append(ds_)

--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -281,7 +281,11 @@ def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
             # Expand along the fourth dimension
             if fourth_dim == "band":
                 # Falls under different bands, use the long_name instead of integer value
-                ds_ = ds_.expand_dims({'band': [ds_.long_name[val-1]]})
+                #ds_ = ds_.expand_dims({'band': [ds_.long_name[val-1]]})
+                if int(ds_['band']) ==1 :
+                    ds_ = ds_.expand_dims({'band': 'SFED'})
+                else:
+                    ds_ = ds_.expand_dims({'band': 'MFED'})
             else:
                 ds_ = ds_.expand_dims([fourth_dim])
             resampled_arrays.append(ds_)

--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -269,7 +269,7 @@ def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
 
     if fourth_dim:  # 4D case
         resampled_arrays = []
-        
+
         for val in ds[fourth_dim].values:
             ds_ = ds.sel({fourth_dim: val})
             ds_ = ds_.rio.reproject(

--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -16,17 +16,6 @@ logger = logging.getLogger(__name__)
 coloredlogs.install(level=LOG_LEVEL, logger=logger)
 
 
-def validate_dimensions(ds):
-    required_dims = {"x", "y", "date"}
-    missing_dims = required_dims - set(ds.dims)
-    if missing_dims:
-        raise ValueError(f"Dataset missing required dimensions: {missing_dims}")
-    # Get the fourth dimension if it exists (not x, y, or date)
-    dims = list(ds.dims)
-    fourth_dim = next((dim for dim in dims if dim not in {"x", "y", "date"}), None)
-    return fourth_dim
-
-
 def fast_zonal_stats_runner(
     ds,
     gdf,
@@ -46,8 +35,7 @@ def fast_zonal_stats_runner(
     Parameters
     ----------
     ds : xarray.Dataset
-        The input raster dataset. Must have dimensions 'x', 'y', and 'date',
-        with an optional fourth dimension (e.g., 'band' or 'leadtime').
+        The input raster dataset. Should have the following dimensions: `x`, `y`, `date`, `leadtime` (optional).
     gdf : geopandas.GeoDataFrame
         A GeoDataFrame containing the administrative boundaries.
     adm_level : int
@@ -77,8 +65,7 @@ def fast_zonal_stats_runner(
         logger = logging.getLogger(__name__)
         logger.addHandler(logging.NullHandler())
 
-    fourth_dim = validate_dimensions(ds)
-
+    # TODO: Pre-compute and save
     # Rasterize the adm bounds
     src_transform = ds.rio.transform()
     src_width = ds.rio.width
@@ -90,14 +77,14 @@ def fast_zonal_stats_runner(
     n_adms = len(adm_ids)
 
     outputs = []
+    # TODO: Can this be vectorized further?
     for date in ds.date.values:
         logger.debug(f"Calculating for {date}...")
         ds_sel = ds.sel(date=date)
-
-        if fourth_dim:  # 4D case
-            for val in ds_sel[fourth_dim].values:
-                ds__ = ds_sel.sel({fourth_dim: val})
-                # Skip if all values are NaN
+        if "leadtime" in ds_sel.dims:
+            for lt in ds_sel.leadtime.values:
+                ds__ = ds_sel.sel(leadtime=lt)
+                # Some leadtime/date combos are invalid and so don't have any data
                 if bool(np.all(np.isnan(ds__.values))):
                     continue
                 results = fast_zonal_stats(
@@ -105,14 +92,12 @@ def fast_zonal_stats_runner(
                 )
                 for i, result in enumerate(results):
                     result["valid_date"] = date
-                    # Special handling for leadtime dimension
-                    if fourth_dim == "leadtime":
-                        result["issued_date"] = add_months_to_date(date, -val)
+                    result["issued_date"] = add_months_to_date(date, -lt)
                     result["pcode"] = adm_ids[i]
                     result["adm_level"] = adm_level
-                    result[fourth_dim] = val  # Store the fourth dimension value
+                    result["leadtime"] = lt
                 outputs.extend(results)
-        else:  # 3D case
+        else:
             results = fast_zonal_stats(
                 ds_sel.values, admin_raster, n_adms, stats=stats, rast_fill=rast_fill
             )
@@ -230,8 +215,7 @@ def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
     Parameters
     ----------
     ds : xarray.Dataset
-        The raster data set to upsample. Must have dimensions 'x', 'y', and 'date',
-        with an optional fourth dimension (e.g., 'band' or 'leadtime').
+        The raster data set to upsample. Must not have >4 dimensions.
     resampled_resolution : float, optional
         The desired resolution for the upsampled raster.
 
@@ -243,8 +227,6 @@ def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
     if logger is None:
         logger = logging.getLogger(__name__)
         logger.addHandler(logging.NullHandler())
-
-    fourth_dim = validate_dimensions(ds)
 
     # Assuming square resolution
     input_resolution = ds.rio.resolution()[0]
@@ -267,28 +249,45 @@ def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
         )
         ds = ds.rio.write_crs("EPSG:4326")
 
-    if fourth_dim:  # 4D case
+    # Forecast data will have 4 dims, since we have a leadtime
+    nd = len(list(ds.dims))
+    if nd == 4:
         resampled_arrays = []
-        for val in ds[fourth_dim].values:
-            ds_ = ds.sel({fourth_dim: val})
-            ds_ = ds_.rio.reproject(
-                ds_.rio.crs,
-                shape=(new_height, new_width),
-                resampling=Resampling.nearest,
-                nodata=np.nan,
-            )
-            # Expand along the fourth dimension
-            ds_ = ds_.expand_dims([fourth_dim])
-            resampled_arrays.append(ds_)
+
+        # TODO: fix the rioxarray.exceptions.NoDataInBounds: Unable to determine bounds from coordinates. here
+        if 'band' in ds.dims:
+            for band in ds.band.values:
+                ds_ = ds.sel(band=band)
+                ds_ = ds_.rio.reproject(
+                    ds_.rio.crs,
+                    shape=(new_height, new_width),
+                    resampling=Resampling.nearest,
+                    nodata=np.nan,
+                )
+                ds_ = ds_.expand_dims(["band"])
+                resampled_arrays.append(ds_)
+        else:
+            for lt in ds.leadtime.values:
+                ds_ = ds.sel(leadtime=lt)
+                ds_ = ds_.rio.reproject(
+                    ds_.rio.crs,
+                    shape=(new_height, new_width),
+                    resampling=Resampling.nearest,
+                    nodata=np.nan,
+                )
+                ds_ = ds_.expand_dims(["leadtime"])
+                resampled_arrays.append(ds_)
 
         ds_resampled = xr.combine_by_coords(resampled_arrays, combine_attrs="drop")
-    else:  # 3D case (x, y, date)
+    elif (nd == 2) or (nd == 3):
         ds_resampled = ds.rio.reproject(
             ds.rio.crs,
             shape=(new_height, new_width),
             resampling=Resampling.nearest,
             nodata=np.nan,
         )
+    else:
+        raise Exception("Input Dataset must have 2, 3, or 4 dimensions.")
 
     return ds_resampled
 

--- a/src/utils/raster_utils.py
+++ b/src/utils/raster_utils.py
@@ -279,7 +279,11 @@ def upsample_raster(ds, resampled_resolution=UPSAMPLED_RESOLUTION, logger=None):
                 nodata=np.nan,
             )
             # Expand along the fourth dimension
-            ds_ = ds_.expand_dims([fourth_dim])
+            if fourth_dim == "band":
+                # Falls under different bands, use the long_name instead of integer value
+                ds_ = ds_.expand_dims({'band': [ds_.long_name[val-1]]})
+            else:
+                ds_ = ds_.expand_dims([fourth_dim])
             resampled_arrays.append(ds_)
 
         ds_resampled = xr.combine_by_coords(resampled_arrays, combine_attrs="drop")

--- a/tests/test_raster_stats.py
+++ b/tests/test_raster_stats.py
@@ -288,17 +288,17 @@ def dataset_with_leadtime(dataset_with_time):
     return ds
 
 
-def test_basic_upsampling(simple_dataset):
+def test_basic_upsampling(dataset_with_time):
     """Test basic upsampling of a 2D dataset."""
     target_res = 0.5  # Upsample from 1.0 to 0.5 degrees
-    result = upsample_raster(simple_dataset, resampled_resolution=target_res)
+    result = upsample_raster(dataset_with_time, resampled_resolution=target_res)
 
     # Check output resolution
     assert result.rio.resolution()[0] == target_res
 
     # Check output dimensions doubled (since resolution halved)
-    assert result.rio.width == simple_dataset.rio.width * 2
-    assert result.rio.height == simple_dataset.rio.height * 2
+    assert result.rio.width == dataset_with_time.rio.width * 2
+    assert result.rio.height == dataset_with_time.rio.height * 2
 
 
 def test_upsampling_with_time(dataset_with_time):

--- a/tests/test_raster_stats.py
+++ b/tests/test_raster_stats.py
@@ -288,6 +288,19 @@ def dataset_with_leadtime(dataset_with_time):
     return ds
 
 
+def test_basic_upsampling(simple_dataset):
+    """Test basic upsampling of a 2D dataset."""
+    target_res = 0.5  # Upsample from 1.0 to 0.5 degrees
+    result = upsample_raster(simple_dataset, resampled_resolution=target_res)
+
+    # Check output resolution
+    assert result.rio.resolution()[0] == target_res
+
+    # Check output dimensions doubled (since resolution halved)
+    assert result.rio.width == simple_dataset.rio.width * 2
+    assert result.rio.height == simple_dataset.rio.height * 2
+
+
 def test_upsampling_with_time(dataset_with_time):
     """Test upsampling of a 3D dataset with time dimension."""
     target_res = 0.5

--- a/tests/test_raster_stats.py
+++ b/tests/test_raster_stats.py
@@ -288,19 +288,6 @@ def dataset_with_leadtime(dataset_with_time):
     return ds
 
 
-def test_basic_upsampling(simple_dataset):
-    """Test basic upsampling of a 2D dataset."""
-    target_res = 0.5  # Upsample from 1.0 to 0.5 degrees
-    result = upsample_raster(simple_dataset, resampled_resolution=target_res)
-
-    # Check output resolution
-    assert result.rio.resolution()[0] == target_res
-
-    # Check output dimensions doubled (since resolution halved)
-    assert result.rio.width == simple_dataset.rio.width * 2
-    assert result.rio.height == simple_dataset.rio.height * 2
-
-
 def test_upsampling_with_time(dataset_with_time):
     """Test upsampling of a 3D dataset with time dimension."""
     target_res = 0.5


### PR DESCRIPTION
WIP to generate raster stats for new Floodscan COG outputs. Since the Floodscan COGs include bands for both SFED and MFED data, I've generalized a bunch of functionality initially developed to handle the SEAS5 `leadtime` dimension. With these changes, the raster stats pipeline should be able to handle any generic 4th dimension (eg. `band` or `leadtime`) coming from the input data. To properly create the Postgres table, this dimension just needs to be specified in the dataset's `config.yml` file (see the `extra_dims` property). 

To do: 

- [x] Handle the fact that Floodscan data only covers Africa. I think we'll want to add a new boolean column (could just call it `floodscan`) to the `iso3` table, which will tell us which ISO3s are covered. So any future datasets that have non-global coverage could get their own similar column. 
- [x] Rename the `band` dimension. This is currently just being pulled from the source COG, where values are either 1 or 2. We need to map these to `SFED` and `MFED` so that the output table is more informative. 
- [x] SEAS5 regression testing. Some of these changes may impact the SEAS5 pipeline, so we need to do some validation to make sure that is still working appropriately. 