### PR TITLE
Fix for cases where there are no extra dims in config

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -37,7 +37,7 @@ def parse_pipeline_config(dataset, test, update, mode):
         end_date = config["end_date"]
         sel_iso3s = None
     forecast = config["forecast"]
-    extra_dims = parse_extra_dims(config.get("extra_dims"))
+    extra_dims = parse_extra_dims(config)
     if not end_date:
         end_date = date.today() - timedelta(days=1)
     if update:

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -113,13 +113,16 @@ def parse_date(filename):
     return pd.to_datetime(res[0])
 
 
-def parse_extra_dims(extra_dims):
+def parse_extra_dims(config):
     parsed_extra_dims = {}
-    for extra_dim in extra_dims:
-        dim = next(iter(extra_dim))
-        if extra_dim[dim] == "str":
-            parsed_extra_dims[dim] = VARCHAR
-        else:
-            parsed_extra_dims[dim] = Integer
+
+    if "extra_dims" in config.keys():
+        extra_dims = config.get("extra_dims")
+        for extra_dim in extra_dims:
+            dim = next(iter(extra_dim))
+            if extra_dim[dim] == "str":
+                parsed_extra_dims[dim] = VARCHAR
+            else:
+                parsed_extra_dims[dim] = Integer
 
     return parsed_extra_dims


### PR DESCRIPTION
The IMERG pipeline has been failing due to missing extra-dims parameter which was added for Floodscan. 
This PR addresses the missing parameter and should fix the issue.