### PR TITLE
Check coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ options:
   -h, --help            show this help message and exit
   --mode {local,dev,prod}, -m {local,dev,prod}
                         Run the pipeline in 'local', 'dev', or 'prod' mode.
+  --update-stats        Calculate stats against the latest COG for a given dataset.
+  --backfill            Whether to check and backfill for any missing dates.
+  --update-metadata     Update the iso3 and polygon metadata tables.
   --test                Processes a smaller subset of the source data. Use to test the pipeline.
 ```
 

--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -153,16 +153,10 @@ if __name__ == "__main__":
         sys.exit(0)
 
     dataset = args.dataset
-    logger.info(f"Updating data for {dataset}...")
+    logger.info("Determining pipeline configuration...")
 
     create_qa_table(engine)
-    (
-        date_chunks,
-        is_forecast,
-        sel_iso3s,
-        extra_dims,
-        frequency,
-    ) = config_pipeline(
+    config = config_pipeline(
         dataset,
         args.test,
         args.update_stats,
@@ -170,8 +164,11 @@ if __name__ == "__main__":
         args.backfill,
         engine,
     )
-    create_dataset_table(dataset, engine, is_forecast, extra_dims)
-    df_iso3s = get_iso3_data(sel_iso3s, engine)
+    create_dataset_table(
+        dataset, engine, config["forecast"], config["extra_dims"]
+    )
+    df_iso3s = get_iso3_data(config["sel_iso3s"], engine)
+    date_chunks = config["date_chunks"]
 
     NUM_PROCESSES = 2
     logger.info(

--- a/run_raster_stats.py
+++ b/run_raster_stats.py
@@ -9,7 +9,11 @@ import geopandas as gpd
 import pandas as pd
 from sqlalchemy import create_engine
 
-from src.config.settings import LOG_LEVEL, UPSAMPLED_RESOLUTION, parse_pipeline_config
+from src.config.settings import (
+    LOG_LEVEL,
+    UPSAMPLED_RESOLUTION,
+    config_pipeline,
+)
 from src.utils.cog_utils import stack_cogs
 from src.utils.database_utils import (
     create_dataset_table,
@@ -18,9 +22,12 @@ from src.utils.database_utils import (
     insert_qa_table,
     postgres_upsert,
 )
-from src.utils.general_utils import split_date_range
 from src.utils.inputs import cli_args
-from src.utils.iso3_utils import create_iso3_df, get_iso3_data, load_shp_from_azure
+from src.utils.iso3_utils import (
+    create_iso3_df,
+    get_iso3_data,
+    load_shp_from_azure,
+)
 from src.utils.metadata_utils import process_polygon_metadata
 from src.utils.raster_utils import fast_zonal_stats_runner, prep_raster
 
@@ -45,13 +52,18 @@ def setup_logger(name, level=logging.INFO):
     return logger
 
 
-def process_chunk(start, end, dataset, mode, df_iso3s, engine_url, chunksize):
+def process_chunk(dates, dataset, mode, df_iso3s, engine_url, chunksize):
     process_name = current_process().name
-    logger = setup_logger(f"{process_name}: {dataset}_{start}")
-    logger.info(f"Starting processing for {dataset} from {start} to {end}")
+    logger = setup_logger(f"{process_name}: {dataset}_{dates[0]}")
+    logger.info(
+        f"""
+        Starting processing for {len(dates)} dates for {dataset}
+        between {dates[0].strftime('%Y-%m-%d')} to {dates[-1].strftime('%Y-%m-%d')}
+        """
+    )
 
     engine = create_engine(engine_url)
-    ds = stack_cogs(start, end, dataset, mode)
+    ds = stack_cogs(dates, dataset, mode)
 
     try:
         for _, row in df_iso3s.iterrows():
@@ -73,13 +85,17 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url, chunksize):
                 except Exception as e:
                     logger.error(f"Error preparing raster for {iso3}: {e}")
                     stack_trace = traceback.format_exc()
-                    insert_qa_table(iso3, None, dataset, e, stack_trace, engine)
+                    insert_qa_table(
+                        iso3, None, dataset, e, stack_trace, engine
+                    )
                     continue
 
                 try:
                     all_results = []
                     for adm_level in range(max_adm + 1):
-                        gdf = gpd.read_file(f"{td}/{iso3.lower()}_adm{adm_level}.shp")
+                        gdf = gpd.read_file(
+                            f"{td}/{iso3.lower()}_adm{adm_level}.shp"
+                        )
                         logger.debug(f"Computing stats for adm{adm_level}...")
                         df_results = fast_zonal_stats_runner(
                             ds_clipped,
@@ -94,7 +110,9 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url, chunksize):
                         if df_results is not None:
                             all_results.append(df_results)
                     df_all_results = pd.concat(all_results, ignore_index=True)
-                    logger.debug(f"Writing {len(df_all_results)} rows to database...")
+                    logger.debug(
+                        f"Writing {len(df_all_results)} rows to database..."
+                    )
                     df_all_results.to_sql(
                         f"{dataset}",
                         con=engine,
@@ -106,7 +124,9 @@ def process_chunk(start, end, dataset, mode, df_iso3s, engine_url, chunksize):
                 except Exception as e:
                     logger.error(f"Error calculating stats for {iso3}: {e}")
                     stack_trace = traceback.format_exc()
-                    insert_qa_table(iso3, adm_level, dataset, e, stack_trace, engine)
+                    insert_qa_table(
+                        iso3, adm_level, dataset, e, stack_trace, engine
+                    )
                     continue
             # Clear memory
             del ds_clipped
@@ -136,32 +156,34 @@ if __name__ == "__main__":
     logger.info(f"Updating data for {dataset}...")
 
     create_qa_table(engine)
-    start, end, is_forecast, sel_iso3s, extra_dims = parse_pipeline_config(
-        dataset, args.test, args.update_stats, args.mode
+    (
+        date_chunks,
+        is_forecast,
+        sel_iso3s,
+        extra_dims,
+        frequency,
+    ) = config_pipeline(
+        dataset,
+        args.test,
+        args.update_stats,
+        args.mode,
+        args.backfill,
+        engine,
     )
     create_dataset_table(dataset, engine, is_forecast, extra_dims)
-
     df_iso3s = get_iso3_data(sel_iso3s, engine)
-    date_ranges = split_date_range(start, end)
 
-    if len(date_ranges) > 1:
-        num_processes = 2
-        logger.info(
-            f"Processing {len(date_ranges)} chunks with {num_processes} processes"
-        )
+    NUM_PROCESSES = 2
+    logger.info(
+        f"Processing {len(date_chunks)} date chunks with {NUM_PROCESSES} processes"
+    )
 
-        process_args = [
-            (start, end, dataset, args.mode, df_iso3s, engine_url, args.chunksize)
-            for start, end in date_ranges
-        ]
+    process_args = [
+        (dates, dataset, args.mode, df_iso3s, engine_url, args.chunksize)
+        for dates in date_chunks
+    ]
 
-        with Pool(num_processes) as pool:
-            pool.starmap(process_chunk, process_args)
-
-    else:
-        logger.info("Processing entire date range in a single chunk")
-        process_chunk(
-            start, end, dataset, args.mode, df_iso3s, engine_url, args.chunksize
-        )
+    with Pool(NUM_PROCESSES) as pool:
+        pool.starmap(process_chunk, process_args)
 
     logger.info("Done calculating and saving stats.")

--- a/src/config/era5.yml
+++ b/src/config/era5.yml
@@ -1,6 +1,7 @@
 blob_prefix: era5/monthly/processed/precip_reanalysis_v
 start_date: 1981-01-01
 end_date: Null
+frequency: M
 forecast: False
 test:
   start_date: 1981-01-01

--- a/src/config/floodscan.yml
+++ b/src/config/floodscan.yml
@@ -1,6 +1,7 @@
 blob_prefix: floodscan/daily/v5/processed/aer_area_300s_
 start_date: 1998-01-12
 end_date: Null
+frequency: D
 forecast: False
 extra_dims:
   - band : str

--- a/src/config/imerg.yml
+++ b/src/config/imerg.yml
@@ -1,6 +1,7 @@
 blob_prefix: imerg/daily/late/v7/processed/imerg-daily-late-
 start_date: 2000-06-01
 end_date: Null
+frequency: D
 forecast: False
 test:
   start_date: 2000-06-01

--- a/src/config/seas5.yml
+++ b/src/config/seas5.yml
@@ -1,6 +1,7 @@
 blob_prefix: seas5/monthly/processed/precip_em_i
 start_date: 1981-01-01
 end_date: Null
+frequency: M
 forecast: True
 extra_dims:
   - leadtime : int

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,15 +1,23 @@
+import logging
 import os
 from datetime import date, timedelta
 
+import coloredlogs
+import pandas as pd
 import yaml
 from dotenv import load_dotenv
 
-from src.utils.general_utils import get_most_recent_date, parse_extra_dims
+from src.utils.general_utils import (
+    get_missing_dates,
+    get_most_recent_date,
+    parse_extra_dims,
+)
 
 load_dotenv()
 
+
 UPSAMPLED_RESOLUTION = 0.05
-LOG_LEVEL = "INFO"
+LOG_LEVEL = "DEBUG"
 AZURE_DB_PW_DEV = os.getenv("AZURE_DB_PW_DEV")
 AZURE_DB_PW_PROD = os.getenv("AZURE_DB_PW_PROD")
 DATABASES = {
@@ -18,15 +26,20 @@ DATABASES = {
     "prod": f"postgresql+psycopg2://chdadmin:{AZURE_DB_PW_PROD}@chd-rasterstats-prod.postgres.database.azure.com/postgres",  # noqa
 }
 
+logger = logging.getLogger(__name__)
+coloredlogs.install(level=LOG_LEVEL, logger=logger)
+
 
 def load_pipeline_config(pipeline_name):
-    config_path = os.path.join(os.path.dirname(__file__), f"{pipeline_name}.yml")
+    config_path = os.path.join(
+        os.path.dirname(__file__), f"{pipeline_name}.yml"
+    )
     with open(config_path, "r") as config_file:
         config = yaml.safe_load(config_file)
     return config
 
 
-def parse_pipeline_config(dataset, test, update, mode):
+def config_pipeline(dataset, test, update, mode, backfill, engine):
     config = load_pipeline_config(dataset)
     if test:
         start_date = config["test"]["start_date"]
@@ -36,12 +49,60 @@ def parse_pipeline_config(dataset, test, update, mode):
         start_date = config["start_date"]
         end_date = config["end_date"]
         sel_iso3s = None
+
     forecast = config["forecast"]
     extra_dims = parse_extra_dims(config)
+
+    frequency = config["frequency"]
     if not end_date:
         end_date = date.today() - timedelta(days=1)
+
+    missing_dates = None
+    if backfill:
+        missing_dates = get_missing_dates(
+            engine, dataset, start_date, end_date, frequency
+        )
+        logger.info(f"Filling in {len(missing_dates)} missing dates:")
+        for date_ in missing_dates:
+            logger.info(f" - {date_.strftime('%Y-%m-%d')}")
+
+    # TODO: Updating by getting the most recent COG is a bit of a shortcut...
     if update:
-        last_update = get_most_recent_date(mode, config["blob_prefix"])
-        start_date = last_update
-        end_date = last_update
-    return start_date, end_date, forecast, sel_iso3s, extra_dims
+        start_date = get_most_recent_date(mode, config["blob_prefix"])
+        end_date = None
+
+    dates = generate_date_series(
+        start_date, end_date, frequency, missing_dates
+    )
+    return dates, forecast, sel_iso3s, extra_dims, frequency
+
+
+def generate_date_series(
+    start_date, end_date, frequency="D", missing_dates=None, chunk_size=100
+):
+    """
+    Generate a sorted list of dates between start and end dates, incorporating missing dates,
+    partitioned into chunks of specified size.
+
+    Parameters:
+    start_date (str or datetime): Start date in 'YYYY-MM-DD' format if string
+    end_date (str or datetime): End date in 'YYYY-MM-DD' format if string
+    frequency (str): 'D' for daily or 'M' for monthly
+    missing_dates (list): Optional list of dates to include, in 'YYYY-MM-DD' format if strings
+    chunk_size (int): Maximum number of dates per partition
+
+    Returns:
+    list of lists: List of date chunks, where each chunk is a list of datetime.date objects
+    """
+    if not end_date:
+        dates = [start_date]
+    else:
+        dates = pd.date_range(
+            start_date, end_date, freq="MS" if frequency == "M" else frequency
+        )
+    if missing_dates:
+        dates.extend(missing_dates)
+    dates = sorted(list(set(dates)))
+    return [
+        dates[i : i + chunk_size] for i in range(0, len(dates), chunk_size)
+    ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -142,19 +142,26 @@ def config_pipeline(dataset, test, update, mode, backfill, engine):
 def generate_date_series(
     start_date, end_date, frequency="D", missing_dates=None, chunk_size=100
 ):
-    """
-    Generate a sorted list of dates between start and end dates, incorporating missing dates,
-    partitioned into chunks of specified size.
+    """Generate a sorted list of dates partitioned into chunks.
 
-    Parameters:
-    start_date (str or datetime): Start date in 'YYYY-MM-DD' format if string
-    end_date (str or datetime): End date in 'YYYY-MM-DD' format if string
-    frequency (str): 'D' for daily or 'M' for monthly
-    missing_dates (list): Optional list of dates to include, in 'YYYY-MM-DD' format if strings
-    chunk_size (int): Maximum number of dates per partition
+    Parameters
+    ----------
+    start_date : str or datetime
+        Start date in 'YYYY-MM-DD' format if string
+    end_date : str or datetime
+        End date in 'YYYY-MM-DD' format if string, or None for single date
+    frequency : str, default='D'
+        Date frequency, either 'D' for daily or 'M' for monthly
+    missing_dates : list, optional
+        Additional dates to include in the series
+    chunk_size : int, default=100
+        Maximum number of dates per chunk
 
-    Returns:
-    list of lists: List of date chunks, where each chunk is a list of datetime.date objects
+    Returns
+    -------
+    list of list of datetime.date
+        List of date chunks, where each chunk contains up to chunk_size dates,
+        sorted in ascending order with duplicates removed
     """
     if not end_date:
         dates = [start_date]

--- a/src/utils/cog_utils.py
+++ b/src/utils/cog_utils.py
@@ -5,12 +5,12 @@ import rioxarray as rxr
 import tqdm
 import xarray as xr
 
-from src.config.settings import load_pipeline_config
+from src.config.settings import LOG_LEVEL, load_pipeline_config
 from src.utils.cloud_utils import get_cog_url, get_container_client
 from src.utils.general_utils import parse_date
 
 logger = logging.getLogger(__name__)
-coloredlogs.install(level="DEBUG", logger=logger)
+coloredlogs.install(level=LOG_LEVEL, logger=logger)
 
 
 # TODO: Update now that IMERG data has the right .attrs metadata
@@ -130,15 +130,13 @@ def stack_cogs(dates, dataset, mode="dev"):
     Stack Cloud Optimized GeoTIFFs (COGs) for a specified date range into an xarray Dataset.
 
     This function retrieves and stacks COGs from a cloud storage container for a given dataset and
-    date range, and returns the stacked data as an `xarray.Dataset`. The data is accessed remotely
+    list of dates, and returns the stacked data as an `xarray.Dataset`. The data is accessed remotely
     and processed into a single `Dataset` with the dimension `date` as the stacking dimension.
 
     Parameters
     ----------
-    start_date : str or datetime-like
-        The start date of the date range for stacking the COGs. This can be a string or a datetime object.
-    end_date : str or datetime-like
-        The end date of the date range for stacking the COGs. This can be a string or a datetime object.
+    dates : list
+        The list of dates for which we want to load in COGs
     dataset : str, optional
         The name of the dataset to retrieve COGs from. Options include "floodscan", "era5", "imerg", and "seas5".
     mode : str, optional

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List
 
 import pandas as pd
@@ -7,37 +7,6 @@ from dateutil.relativedelta import relativedelta
 from sqlalchemy import VARCHAR, Integer
 
 from src.utils.cloud_utils import get_container_client
-
-
-def split_date_range(start_date, end_date):
-    """
-    Split the date range into yearly chunks if the range is greater than a year.
-
-    Parameters
-    ----------
-    start_date (str): Start date in 'YYYY-MM-DD' format
-    end_date (str): End date in 'YYYY-MM-DD' format
-
-    Returns
-    -------
-    list of tuples: Each tuple contains the start and end date for a chunk
-    """
-    start = pd.to_datetime(start_date)
-    end = pd.to_datetime(end_date)
-
-    # If the date range is less than or equal to a year, return it as a single chunk
-    if (end - start).days <= 365:
-        return [(start_date, end_date)]
-
-    date_ranges = []
-    while start < end:
-        year_end = min(datetime(start.year, 12, 31), end)
-        date_ranges.append(
-            (start.strftime("%Y-%m-%d"), year_end.strftime("%Y-%m-%d"))
-        )
-        start = year_end + timedelta(days=1)
-
-    return date_ranges
 
 
 def add_months_to_date(date_string, months):

--- a/src/utils/inputs.py
+++ b/src/utils/inputs.py
@@ -28,7 +28,7 @@ def cli_args():
     )
     parser.add_argument(
         "--update-stats",
-        help="""Calculates stats based on recently updated data""",
+        help="""Calculate stats against the latest COG for a given dataset.""",
         action="store_true",
     )
     parser.add_argument(

--- a/src/utils/inputs.py
+++ b/src/utils/inputs.py
@@ -42,4 +42,9 @@ def cli_args():
         type=int,
         default=100000,
     )
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Whether to check and backfill for any missing dates",
+    )
     return parser.parse_args()


### PR DESCRIPTION
Addresses #26. To accomplish this, I've adjusted the handling of dates to be based on an input list, rather than a range defined by start and end dates. I think this is cleaner overall. Since the config is a bit more complex, I've also added much more detailed logging to the beginning of the pipeline run: 

![Screenshot 2024-12-11 at 3 19 46 PM](https://github.com/user-attachments/assets/39ba2e84-f6c6-4293-96a0-7b9a8daa6a01)
